### PR TITLE
TC: Improve mixed-sig binding group generalisation

### DIFF
--- a/src/Syntax/Concrete/Definition.hs
+++ b/src/Syntax/Concrete/Definition.hs
@@ -91,6 +91,10 @@ instance (Pretty (expr v), Monad expr, IsString v, void ~ Void)
   prettyM = prettyNamed "_"
 
 instance (Pretty (expr v), Monad expr, IsString v)
+  => Pretty (TopLevelPatDefinition expr v) where
+  prettyM = prettyNamed "_"
+
+instance (Pretty (expr v), Monad expr, IsString v)
   => PrettyNamed (TopLevelPatDefinition expr v) where
   prettyNamed name (TopLevelPatDefinition d) = prettyNamed name d
   prettyNamed name (TopLevelPatDataDefinition dataDef) = prettyNamed name dataDef

--- a/tests/success/typechecking/SignatureGeneralisation.vix
+++ b/tests/success/typechecking/SignatureGeneralisation.vix
@@ -1,0 +1,4 @@
+apply : forall f a b. (f a -> b) -> f a -> b
+apply f x = apply1 f x
+
+apply1 f x = apply f x


### PR DESCRIPTION
Fixes #43.

Change the strategy for typechecking binding groups with and without
signatures. First typecheck and generalise the definitions without
signatures, assuming the signatures are correct. After generalising the
definitions without signatures we typecheck and generalise the ones with
signature.

This touches more code than expected because it requires propagating
whether definitions have signatures (the `Type v` to `Maybe (Type v)`
changes).