### PR TITLE
Add and use FreeVar types instead of MetaVars

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -40,6 +40,7 @@ executable sixten
                        Command.Compile.Options
                        Command.Run
                        Command.Test
+                       FreeVar
                        Frontend.Declassify
                        Frontend.Parse
                        Frontend.ScopeCheck
@@ -88,6 +89,7 @@ executable sixten
                        Syntax.SourceLoc
                        Syntax.Telescope
                        TypeRep
+                       TypedFreeVar
                        VIX
                        Util
                        Util.MultiHashMap

--- a/src/FreeVar.hs
+++ b/src/FreeVar.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+module FreeVar where
+
+import Control.Monad.IO.Class
+import Data.Function
+import Data.Hashable
+
+import Syntax.Hint
+import VIX
+
+data FreeVar d = FreeVar
+  { varId :: !Int
+  , varHint :: !NameHint
+  , varData :: d
+  } deriving Show
+
+instance Eq (FreeVar d) where
+  (==) = (==) `on` varId
+
+instance Ord (FreeVar d) where
+  compare = compare `on` varId
+
+instance Hashable (FreeVar d) where
+  hashWithSalt s = hashWithSalt s . varId
+
+freeVar
+  :: (MonadVIX m, MonadIO m)
+  => NameHint
+  -> d
+  -> m (FreeVar d)
+freeVar h d = do
+  i <- fresh
+  return $ FreeVar i h d

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -9,9 +9,9 @@ import Data.Function
 import Data.Functor.Classes
 import Data.Hashable
 import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashSet as HashSet
 import Data.Maybe
 import Data.Monoid
-import qualified Data.Set as Set
 import Data.STRef
 import Data.String
 import Data.Vector(Vector)
@@ -193,9 +193,9 @@ abstractM f e = do
       sol <- solution r
       case sol of
         Left _ -> do
-          tfvs <- foldMapMetas Set.singleton $ metaType v'
-          let mftfvs = Set.filter (isJust . f) tfvs
-          unless (Set.null mftfvs)
+          tfvs <- foldMapMetas HashSet.singleton $ metaType v'
+          let mftfvs = HashSet.filter (isJust . f) tfvs
+          unless (HashSet.null mftfvs)
             $ throwError $ "cannot abstract, " ++ show mftfvs ++ " would escape from the type of "
             ++ show v'
           free v'
@@ -322,10 +322,10 @@ showMeta
   => f (MetaVar d e)
   -> m Doc
 showMeta x = do
-  vs <- foldMapMetas Set.singleton x
+  vs <- foldMapMetas HashSet.singleton x
   let p MetaVar { metaRef = Exists r } = solution r
       p _ = return $ Left $ Level (-1)
-  let vsl = Set.toList vs
+  let vsl = HashSet.toList vs
   pvs <- mapM p vsl
   let sv v = "$" ++ fromMaybe "" (fromName <$> unNameHint (metaHint v)) ++ refType (metaRef v)
           ++ show (metaId v)

--- a/src/TypedFreeVar.hs
+++ b/src/TypedFreeVar.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+module TypedFreeVar where
+
+import Control.Monad.IO.Class
+import Control.Monad.State
+import Data.Function
+import Data.Functor.Classes
+import Data.Hashable
+import qualified Data.HashSet as HashSet
+import Data.Maybe
+import Data.Monoid
+import Data.String
+
+import Pretty
+import Syntax.Hint
+import Syntax.Name
+import VIX
+
+data FreeVar d = FreeVar
+  { varId :: !Int
+  , varHint :: !NameHint
+  , varType :: d (FreeVar d)
+  }
+
+instance Show1 d => Show (FreeVar d) where
+  showsPrec d (FreeVar i h t) = showParen (d > 10) $
+    showString "FreeVar" . showChar ' ' . showsPrec 11 i .
+    showChar ' ' . showsPrec 11 h . showChar ' ' . showsPrec1 11 t
+
+instance Eq (FreeVar d) where
+  (==) = (==) `on` varId
+
+instance Ord (FreeVar d) where
+  compare = compare `on` varId
+
+instance Hashable (FreeVar d) where
+  hashWithSalt s = hashWithSalt s . varId
+
+freeVar
+  :: (MonadVIX m, MonadIO m)
+  => NameHint
+  -> d (FreeVar d)
+  -> m (FreeVar d)
+freeVar h d = do
+  i <- fresh
+  return $ FreeVar i h d
+
+showFreeVar
+  :: (Functor d, Functor f, Foldable f, Pretty (f String), Pretty (d String))
+  => f (FreeVar d)
+  -> Doc
+showFreeVar x = do
+  let vs = foldMap HashSet.singleton x
+  let showVar v = "$" ++ fromMaybe "" (fromName <$> unNameHint (varHint v))
+          ++ show (varId v)
+  let shownVars = [(showVar v, pretty $ showVar <$> varType v) | v <- HashSet.toList vs]
+  pretty (showVar <$> x)
+    <> if null shownVars
+      then mempty
+      else text ", free vars: " <> pretty shownVars
+
+logFreeVar
+  :: (Functor d, Functor f, Foldable f, Pretty (f String), Pretty (d String), MonadVIX m, MonadIO m)
+  => Int
+  -> String
+  -> f (FreeVar d)
+  -> m ()
+logFreeVar v s x = whenVerbose v $ do
+  i <- gets vixIndent
+  let r = showFreeVar x
+  VIX.log $ mconcat (replicate i "| ") <> "--" <> fromString s <> ": " <> showWide r


### PR DESCRIPTION
... in the compiler passes that don't need the full generality of
MetaVars (unification etc), but just need unique variables with an
attached data or type.

We introduce two kinds of free variables representations:
FreeVar.FreeVar for when only some data needs to be attached, and
TypedFreeVar.FreeVar for when a type filled with free vars needs to be
attached. We change the lambda lifter, closure conversion, and return
direction analysis pass to use these new kinds of free variable.

This fixes #11.