### PR TITLE
Move Level from VIX to Infer monad

### DIFF
--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, ViewPatterns, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, ViewPatterns, OverloadedStrings #-}
 module Meta where
 
 import Control.Monad.Except
@@ -21,6 +21,12 @@ import qualified Syntax.Abstract as Abstract
 import qualified Syntax.Concrete.Scoped as Concrete
 import qualified Syntax.Sized.SLambda as SLambda
 import VIX
+
+newtype Level = Level Int
+  deriving (Eq, Num, Ord, Show)
+
+instance Pretty Level where
+  pretty (Level i) = pretty i
 
 type Exists d e = STRef RealWorld (Either Level (e (MetaVar d e)))
 
@@ -103,14 +109,6 @@ existsAtLevel hint d typ l = do
   ref <- liftST $ newSTRef $ Left l
   logVerbose 20 $ "exists: " <> fromString (show i)
   return $ MetaVar i typ hint (Exists ref) d
-
-exists
-  :: (MonadVIX m, MonadIO m)
-  => NameHint
-  -> d
-  -> e (MetaVar d e)
-  -> m (MetaVar d e)
-exists hint d typ = existsAtLevel hint d typ =<< level
 
 shared
   :: (MonadVIX m, MonadIO m)

--- a/src/VIX.hs
+++ b/src/VIX.hs
@@ -25,12 +25,6 @@ import qualified Syntax.Sized.Lifted as Lifted
 import Util.MultiHashMap(MultiHashMap)
 import qualified Util.MultiHashMap as MultiHashMap
 
-newtype Level = Level Int
-  deriving (Eq, Num, Ord, Show)
-
-instance Pretty Level where
-  pretty (Level i) = pretty i
-
 data VIXState = VIXState
   { vixLocation :: SourceLoc
   , vixContext :: HashMap QName (Definition Expr Void, Type Void)
@@ -41,7 +35,6 @@ data VIXState = VIXState
   , vixClassInstances :: HashMap QName [(QName, Type Void)]
   , vixIndent :: !Int
   , vixFresh :: !Int
-  , vixLevel :: !Level
   , vixLogHandle :: !Handle
   , vixVerbosity :: !Int
   , vixTarget :: Target
@@ -60,7 +53,6 @@ emptyVIXState target handle verbosity = VIXState
   , vixClassInstances = mempty
   , vixIndent = 0
   , vixFresh = 0
-  , vixLevel = Level 1
   , vixLogHandle = handle
   , vixVerbosity = verbosity
   , vixTarget = target
@@ -94,17 +86,6 @@ fresh = do
   i <- gets vixFresh
   modify $ \s -> s {vixFresh = i + 1}
   return i
-
-level :: MonadVIX m => m Level
-level = gets vixLevel
-
-enterLevel :: MonadVIX m => m a -> m a
-enterLevel x = do
-  l <- level
-  modify $ \s -> s {vixLevel = l + 1}
-  r <- x
-  modify $ \s -> s {vixLevel = l}
-  return r
 
 located :: MonadVIX m => SourceLoc -> m a -> m a
 located loc m = do


### PR DESCRIPTION
The level is only used in the type inferencer, so it should be there.