### PR TITLE
Remove type variable from Unscoped syntax

### DIFF
--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -49,13 +49,13 @@ import VIX
 type DependencySigs = HashMap QName Text
 
 process
-  :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))
+  :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [Extracted.Submodule (Generate.Generated (Text, DependencySigs))]
 process = frontend backend
 
 frontend
   :: ([(QName, Definition Abstract.Expr Void, Abstract.Expr Void)] -> VIX [k])
-  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))
+  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [k]
 frontend k
   = scopeCheckProgram
@@ -178,7 +178,7 @@ prettyGroup str f defs = do
   return defs
 
 scopeCheckProgram
-  :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))
+  :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [[(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Type Void))]]
 scopeCheckProgram m = do
   res <- ScopeCheck.scopeCheckModule m
@@ -327,7 +327,7 @@ writeModule modul llOutputFile externOutputFiles = do
 
 parse
   :: FilePath
-  -> IO (Result (Module [(SourceLoc, Unscoped.TopLevelDefinition QName)]))
+  -> IO (Result (Module [(SourceLoc, Unscoped.TopLevelDefinition)]))
 parse file = do
   parseResult <- Parse.parseFromFileEx Parse.modul file
   case parseResult of
@@ -335,8 +335,8 @@ parse file = do
     Trifecta.Success res -> return $ Success res
 
 dupCheck
-  :: Module [(SourceLoc, Unscoped.TopLevelDefinition QName)]
-  -> Result (Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName)))
+  :: Module [(SourceLoc, Unscoped.TopLevelDefinition)]
+  -> Result (Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition)))
 dupCheck m = forM m $ flip evalStateT (0 :: Int) . foldM go mempty
   where
     go defs (loc, def) = do

--- a/src/Processor/Files.hs
+++ b/src/Processor/Files.hs
@@ -58,7 +58,7 @@ processFiles args = do
 
 processModules
   :: Arguments
-  -> [Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))]
+  -> [Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))]
   -> IO (Result [Module [Extracted.Submodule (Generate.Generated (Text, File.DependencySigs))]])
 processModules args (builtins1 : builtins2 : modules) = do
   result <- runVIX go tgt (logHandle args) (verbosity args)
@@ -81,8 +81,8 @@ processModules _ _ = error "processModules"
 
 processBuiltins
   :: Target
-  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))
-  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition QName))
+  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
+  -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [Extracted.Submodule (Generate.Generated (Text, File.DependencySigs))]
 processBuiltins tgt builtins1 builtins2 = do
   let builtinDefNames = HashSet.fromMap $ void context

--- a/src/Syntax/Concrete/Literal.hs
+++ b/src/Syntax/Concrete/Literal.hs
@@ -13,13 +13,13 @@ import Syntax.Concrete.Unscoped as Unscoped
 
 import qualified Builtin.Names as Builtin
 
-string :: Text -> Expr QName
+string :: Text -> Expr
 string
   = App (Var $ QName "Sixten.Builtin" $ fromConstr Builtin.MkStringName) Explicit
   . byteArray
   . Encoding.encodeUtf8
 
-byteArray :: ByteString -> Expr QName
+byteArray :: ByteString -> Expr
 byteArray bs
   = Unscoped.apps (Var $ unqualified $ constrToName Builtin.MkArrayName)
   [ (Explicit, nat $ ByteString.length bs)
@@ -32,7 +32,7 @@ byteArray bs
     )
   ]
 
-nat :: (Eq a, Num a) => a -> Expr QName
+nat :: (Eq a, Num a) => a -> Expr
 nat 0 = Var $ unqualified $ constrToName Builtin.ZeroName
 nat n = App (Var $ unqualified $ constrToName Builtin.SuccName) Explicit (nat (n - 1))
 

--- a/src/Syntax/Concrete/Unscoped.hs
+++ b/src/Syntax/Concrete/Unscoped.hs
@@ -1,14 +1,9 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Syntax.Concrete.Unscoped where
 
-import Control.Monad
-import Data.Bifunctor
-import Data.Bitraversable
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty(NonEmpty)
 import Data.Monoid
-import Data.String
-import Data.Traversable
 import Data.Vector(Vector)
 
 import Syntax hiding (Definition)
@@ -16,95 +11,61 @@ import Syntax.Concrete.Pattern
 
 type Con = Either Constr QConstr
 
--- TODO: Maybe the types in this module don't need the type variable?
-data Expr v
-  = Var v
+data Expr
+  = Var QName
   | Lit Literal
-  | Pi !Plicitness (Pat (Type v) QName) (Expr v)
-  | Lam !Plicitness (Pat (Type v) QName) (Expr v)
-  | App (Expr v) !Plicitness (Expr v)
-  | Let (Vector (SourceLoc, Definition Expr v)) (Expr v)
-  | Case (Expr v) [(Pat (Expr v) QName, Expr v)]
-  | ExternCode (Extern (Expr v))
+  | Pi !Plicitness (Pat Type QName) Expr
+  | Lam !Plicitness (Pat Type QName) Expr
+  | App Expr !Plicitness Expr
+  | Let (Vector (SourceLoc, Definition Expr)) Expr
+  | Case Expr [(Pat Expr QName, Expr)]
+  | ExternCode (Extern Expr)
   | Wildcard
-  | SourceLoc !SourceLoc (Type v)
+  | SourceLoc !SourceLoc Type
   deriving Show
 
 type Type = Expr
 
-data Definition e v
-  = Definition Name Abstract (NonEmpty (Clause e v)) (Maybe (e v))
-  deriving (Show, Functor, Foldable, Traversable)
-
-definitionName :: Definition e v -> Name
-definitionName (Definition n _ _ _) = n
-
-data TopLevelDefinition v
-  = TopLevelDefinition (Definition Expr v)
-  | TopLevelDataDefinition Name [(Plicitness, Name, Type v)] [ConstrDef (Expr v)]
-  | TopLevelClassDefinition Name [(Plicitness, Name, Type v)] [MethodDef (Expr v)]
-  | TopLevelInstanceDefinition (Type v) [(SourceLoc, Definition Expr v)]
+data Definition e
+  = Definition Name Abstract (NonEmpty (Clause e)) (Maybe e)
   deriving (Show)
 
-data Clause e v = Clause (Vector (Plicitness, Pat (e v) QName)) (e v)
+definitionName :: Definition e -> Name
+definitionName (Definition n _ _ _) = n
+
+data TopLevelDefinition
+  = TopLevelDefinition (Definition Expr)
+  | TopLevelDataDefinition Name [(Plicitness, Name, Type)] [ConstrDef Expr]
+  | TopLevelClassDefinition Name [(Plicitness, Name, Type)] [MethodDef Expr]
+  | TopLevelInstanceDefinition Type [(SourceLoc, Definition Expr)]
+  deriving (Show)
+
+data Clause e = Clause (Vector (Plicitness, Pat e QName)) e
   deriving (Show)
 
 -------------------------------------------------------------------------------
 -- Smart constructors
 pis
-  :: [(Plicitness, Pat (Type v) QName)]
-  -> Expr v
-  -> Expr v
+  :: [(Plicitness, Pat Type QName)]
+  -> Expr
+  -> Expr
 pis ps e = foldr (uncurry Pi) e ps
 
 lams
-  :: [(Plicitness, Pat (Type v) QName)]
-  -> Expr v
-  -> Expr v
+  :: [(Plicitness, Pat Type QName)]
+  -> Expr
+  -> Expr
 lams ps e = foldr (uncurry Lam)  e ps
 
 apps
-  :: Expr v
-  -> [(Plicitness, Expr v)]
-  -> Expr v
+  :: Expr
+  -> [(Plicitness, Expr)]
+  -> Expr
 apps = foldl (\e1 (p, e2) -> App e1 p e2)
 
 -------------------------------------------------------------------------------
 -- Instances
-instance Applicative Expr where
-  pure = return
-  (<*>) = ap
-
-instance Monad Expr where
-  return = Var
-  expr >>= f = case expr of
-    Var v -> f v
-    Lit l -> Lit l
-    Pi p pat e -> Pi p (first (>>= f) pat) (e >>= f)
-    Lam p pat e -> Lam p (first (>>= f) pat) (e >>= f)
-    App e1 p e2 -> App (e1 >>= f) p (e2 >>= f)
-    Let ds e -> Let (bimap id (>>>= f) <$> ds) (e >>= f)
-    Case e brs -> Case (e >>= f) [(first (>>= f) pat, br >>= f) | (pat, br) <- brs]
-    ExternCode c -> ExternCode $ (>>= f) <$> c
-    Wildcard -> Wildcard
-    SourceLoc loc e -> SourceLoc loc (e >>= f)
-
-instance Functor Expr where fmap = fmapDefault
-instance Foldable Expr where foldMap = foldMapDefault
-instance Traversable Expr where
-  traverse f expr = case expr of
-    Var v -> Var <$> f v
-    Lit l -> pure $ Lit l
-    Pi p pat e -> Pi p <$> bitraverse (traverse f) pure pat <*> traverse f e
-    Lam p pat e -> Lam p <$> bitraverse (traverse f) pure pat <*> traverse f e
-    App e1 p e2 -> App <$> traverse f e1 <*> pure p <*> traverse f e2
-    Let ds e -> Let <$> traverse (bitraverse pure (traverse f)) ds <*> traverse f e
-    Case e brs -> Case <$> traverse f e <*> traverse (bitraverse (bitraverse (traverse f) pure) (traverse f)) brs
-    ExternCode c -> ExternCode <$> traverse (traverse f) c
-    Wildcard -> pure Wildcard
-    SourceLoc loc e -> SourceLoc loc <$> traverse f e
-
-instance (Eq v, IsString v, Pretty v) => Pretty (Expr v) where
+instance Pretty Expr where
   prettyM expr = case expr of
     Var v -> prettyM v
     Lit l -> prettyM l
@@ -123,27 +84,11 @@ instance (Eq v, IsString v, Pretty v) => Pretty (Expr v) where
     Wildcard -> "_"
     SourceLoc _ e -> prettyM e
 
-instance Bound Definition where
-  Definition n a cls mtyp >>>= f = Definition n a ((>>>= f) <$> cls) ((>>= f) <$> mtyp)
-
-instance (Eq v, IsString v, Pretty v, Pretty (e v)) => Pretty (Definition e v) where
+instance Pretty e => Pretty (Definition e) where
   prettyM (Definition name a cls Nothing)
     = prettyM a <$$> vcat (prettyNamed (prettyM name) <$> cls)
   prettyM (Definition name a cls (Just typ))
     = prettyM a <$$> vcat (NonEmpty.cons (prettyM name <+> ":" <+> prettyM typ) (prettyNamed (prettyM name) <$> cls))
 
-instance Traversable e => Functor (Clause e) where
-  fmap = fmapDefault
-
-instance Traversable e => Foldable (Clause e) where
-  foldMap = foldMapDefault
-
-instance Traversable e => Traversable (Clause e) where
-  traverse f (Clause pats body)
-    = Clause <$> traverse (traverse $ bitraverse (traverse f) pure) pats <*> traverse f body
-
-instance Bound Clause where
-  Clause pats body >>>= f = Clause (second (first (>>= f)) <$> pats) (body >>= f)
-
-instance (Eq v, IsString v, Pretty v, Pretty (e v)) => PrettyNamed (Clause e v) where
+instance (Pretty e) => PrettyNamed (Clause e) where
   prettyNamed name (Clause pats body) = name <+> hcat ((\(p, pat) -> prettyAnnotation p (prettyM pat)) <$> pats) <+> "=" <+> prettyM body


### PR DESCRIPTION
It was always used as QName anyway.