### PR TITLE
Adds the config flag along with automatically trying out different version numbers

### DIFF
--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Backend.Compile where
 
+import Control.Exception
 import Control.Monad
 import Data.Foldable
 import Data.Maybe
 import Data.Monoid
+import Data.Version
 import System.FilePath
 import System.Process
 
@@ -20,34 +24,57 @@ data Arguments = Arguments
   , outputFile :: !FilePath
   }
 
+supportedLlvmVersions :: [Version]
+supportedLlvmVersions = makeVersion <$> [[5, 0], [4, 0]]
+
+llvmBinSuffix :: IO String
+llvmBinSuffix = checkLlvmExists trySuffixes
+  where trySuffixes = "" : fmap (('-' :) . showVersion) supportedLlvmVersions
+        checkLlvmExists :: [String] -> IO String
+        checkLlvmExists (suffix : xs) =
+          handle (\(_ :: IOException) -> checkLlvmExists xs) $ do
+          _ <- readProcess ("llvm-config" ++ suffix) ["--version"] ""
+          return suffix
+        checkLlvmExists [] =
+          error "Couldn't find LLVM binaries for supported versions.\n\
+                \Try using the --llvm-config flag."
+
 compile :: Options -> Arguments -> IO ()
 compile opts args = do
-  cLlFiles <- forM (cFiles args) $ compileC opts $ target args
-  linkedLlFile <- linkLlvm (llFiles args ++ toList cLlFiles) $ linkedLlFileName args
-  optLlFile <- optimiseLlvm opts linkedLlFile
-  objFile <- compileLlvm opts (target args) optLlFile
-  assemble opts objFile $ outputFile args
+  suffix <- llvmBinSuffix
+  let opt = "opt" ++ suffix
+  let clang = "clang" ++ suffix
+  let linker = "llvm-link" ++ suffix
+  let compiler = "llc" ++ suffix
+  cLlFiles <- forM (cFiles args) $ compileC clang opts $ target args
+  linkedLlFile <- linkLlvm linker (llFiles args ++ toList cLlFiles)
+    $ linkedLlFileName args
+  optLlFile <- optimiseLlvm opt opts linkedLlFile
+  objFile <- compileLlvm compiler opts (target args) optLlFile
+  assemble clang opts objFile $ outputFile args
 
 optimisationFlags :: Options -> [String]
 optimisationFlags opts = case Options.optimisation opts of
   Nothing -> []
   Just optLevel -> ["-O" <> optLevel]
 
-optimiseLlvm :: Options -> FilePath -> IO FilePath
-optimiseLlvm opts file
+type Binary = FilePath
+
+optimiseLlvm :: Binary -> Options -> FilePath -> IO FilePath
+optimiseLlvm opt opts file
   | isNothing $ Options.optimisation opts = return file
   | otherwise = do
     let optLlFile = replaceExtension file "opt.ll"
-    callProcess "opt" $ optimisationFlags opts ++
+    callProcess opt $ optimisationFlags opts ++
       [ "-S", file
       , "-o", optLlFile
       ]
     return optLlFile
 
-compileC :: Options -> Target -> FilePath -> IO FilePath
-compileC opts tgt cFile = do
+compileC :: Binary -> Options -> Target -> FilePath -> IO FilePath
+compileC clang opts tgt cFile = do
   let output = cFile <> ".ll"
-  callProcess "clang" $ optimisationFlags opts ++
+  callProcess clang $ optimisationFlags opts ++
     [ "-march=" <> Target.architecture tgt
     , "-fvisibility=internal"
     , "-fPIC"
@@ -58,14 +85,14 @@ compileC opts tgt cFile = do
     ]
   return output
 
-linkLlvm :: [FilePath] -> FilePath -> IO FilePath
-linkLlvm [file] _outFile = return file
-linkLlvm files outFile = do
-  callProcess "llvm-link" $ ["-o=" <> outFile, "-S"] ++ files
+linkLlvm :: Binary -> [FilePath] -> FilePath -> IO FilePath
+linkLlvm _ [file] _outFile = return file
+linkLlvm linker files outFile = do
+  callProcess linker $ ["-o=" <> outFile, "-S"] ++ files
   return outFile
 
-compileLlvm :: Options -> Target -> FilePath -> IO FilePath
-compileLlvm opts tgt llFile = do
+compileLlvm :: Binary -> Options -> Target -> FilePath -> IO FilePath
+compileLlvm compiler opts tgt llFile = do
   let flags ft o
         = optimisationFlags opts ++
         [ "-filetype=" <> ft
@@ -77,14 +104,14 @@ compileLlvm opts tgt llFile = do
       asmFile = replaceExtension llFile "s"
       objFile = replaceExtension llFile "o"
   when (isJust $ Options.assemblyDir opts) $
-    callProcess "llc" $ flags "asm" asmFile
-  callProcess "llc" $ flags "obj" objFile
+    callProcess compiler $ flags "asm" asmFile
+  callProcess compiler $ flags "obj" objFile
   return objFile
 
-assemble :: Options -> FilePath -> FilePath -> IO ()
-assemble opts objFile outFile = do
+assemble :: Binary -> Options -> FilePath -> FilePath -> IO ()
+assemble clang opts objFile outFile = do
   ldFlags <- readProcess "pkg-config" ["--libs", "--static", "bdw-gc"] ""
-  callProcess "clang"
+  callProcess clang
     $ concatMap words (lines ldFlags)
     ++ optimisationFlags opts
     ++ [objFile, "-o", outFile]

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -75,9 +75,8 @@ optionsParser = Options
     )
   <*> optional (strOption
     $ long "llvm-config"
-    <> metavar "VERSION"
-    <> help "Version suffix of the llvm-config binary. For example, if the \
-            \binary is llvm-config-X.Y then specify X.Y."
+    <> metavar "PATH"
+    <> help "Path to the llvm-config binary."
     <> action "file"
     )
 

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -73,6 +73,13 @@ optionsParser = Options
     <> help "Write logs to FILE instead of standard output"
     <> action "file"
     )
+  <*> optional (strOption
+    $ long "llvm-config"
+    <> metavar "VERSION"
+    <> help "Version suffix of the llvm-config binary. For example, if the \
+            \binary is llvm-config-X.Y then specify X.Y."
+    <> action "file"
+    )
 
 compile
   :: Options

--- a/src/Command/Compile/Options.hs
+++ b/src/Command/Compile/Options.hs
@@ -10,4 +10,5 @@ data Options = Options
   , assemblyDir :: Maybe FilePath
   , verbosity :: Int
   , logFile :: Maybe FilePath
+  , llvmConfig :: Maybe String
   } deriving (Show)

--- a/src/Command/Compile/Options.hs
+++ b/src/Command/Compile/Options.hs
@@ -10,5 +10,5 @@ data Options = Options
   , assemblyDir :: Maybe FilePath
   , verbosity :: Int
   , logFile :: Maybe FilePath
-  , llvmConfig :: Maybe String
+  , llvmConfig :: Maybe FilePath
   } deriving (Show)


### PR DESCRIPTION
Fixes #65. I've used the approach of just trying to see if the binary exists using `readProcess` and using exceptions instead of

1. Trying to obtain the path and searching it manually -- seems like too much work. We have to shell out later anyways.
2. Relying on yet another binary such as `which` and checking the exit code (dunno if Windows has `which`).
3. Running the naked command and redirecting the `stdout` and `stderr` to `/dev/null` (Windows solution will be slightly different, it has `NUL` I think).
4. Building a command from scratch and redirecting the handlers -- again too much work.

Of course, if you feel that I should take one of these approaches or something else, I'm happy to tweak the code :).

We will have to change the suffix for Windows though (#69).

Note: the output for `llvm-config-5.0 --bindir` gives a directory which has binaries named `clang` etc. which are symlinked from `/usr/bin/clang-5.0` etc. So we could get rid of the version suffixes in several places if we use that approach.