### PR TITLE
Minor typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ garbage-collecting heap-allocated data.
 ## Planned features
 
 * Inductive families/indexed types
-* Editor integration (there's already Vim syntax highlighting though!!1)
+* Editor integration (there's already Vim syntax highlighting though!!)
 * Records
 * Effects and IO
 * Standard library

--- a/src/Command/Check.hs
+++ b/src/Command/Check.hs
@@ -54,7 +54,7 @@ check opts onError = withLogHandle (logFile opts) $ \logHandle -> do
         }
   case procResult of
     Processor.Failure errs -> onError errs
-    Processor.Success _ -> Text.putStrLn "✔ Type checking completed succesfully"
+    Processor.Success _ -> Text.putStrLn "Type checking completed successfully"
   where
     withLogHandle Nothing k = k stdout
     withLogHandle (Just file) k = Util.withFile file WriteMode k

--- a/src/Inference/Normalise.hs
+++ b/src/Inference/Normalise.hs
@@ -39,7 +39,7 @@ data WhnfArgs m = WhnfArgs
     -- ^ Should types be reduced to type representations (i.e. forget what the
     -- type is and only remember its representation)?
   , handleUnsolvedConstraint :: !(AbstractM -> m (Maybe AbstractM))
-    -- ^ Allows whnf to try to solve an unsoilved class constraint when they're
+    -- ^ Allows whnf to try to solve an unsolved class constraint when they're
     -- encountered.
   }
 


### PR DESCRIPTION
 - Fixes some minor spelling mistakes.
 - Remove unicode character from `check` command output due to [an issue with Windows consoles](https://ghc.haskell.org/trac/ghc/ticket/8118)