### PR TITLE
Make MonadVIX an mtl-style class

### DIFF
--- a/src/Backend/ClosureConvert.hs
+++ b/src/Backend/ClosureConvert.hs
@@ -3,7 +3,6 @@ module Backend.ClosureConvert where
 
 import Control.Applicative
 import Control.Monad.Except
-import Control.Monad.State
 import Data.Bifunctor
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Maybe
@@ -150,8 +149,8 @@ unknownCall
   -> Vector (Expr FV)
   -> ClosureConvert (Expr FV)
 unknownCall e es = do
-  ptrRep <- lift $ gets (MkType . TypeRep.ptrRep . vixTarget)
-  intRep <- lift $ gets (MkType . TypeRep.intRep . vixTarget)
+  ptrRep <- MkType <$> getPtrRep
+  intRep <- MkType <$> getIntRep
   return
     $ Call (global $ Builtin.applyName $ Vector.length es)
     $ Vector.cons (Sized ptrRep e)
@@ -164,8 +163,8 @@ knownCall
   -> ClosureConvert (Expr FV)
 knownCall f (tele, returnTypeScope) args
   | numArgs < arity = do
-    vs <- lift $ forM (teleNames tele) $ \h -> freeVar h ()
-    target <- lift $ gets vixTarget
+    vs <- forM (teleNames tele) $ \h -> freeVar h ()
+    target <- getTarget
     let intRep, ptrRep :: Expr v
         intRep = MkType $ TypeRep.intRep target
         ptrRep = MkType $ TypeRep.ptrRep target

--- a/src/Backend/Lift.hs
+++ b/src/Backend/Lift.hs
@@ -27,7 +27,7 @@ data LiftState thing = LiftState
   }
 
 newtype Lift thing m a = Lift (StateT (LiftState thing) m a)
-  deriving (Functor, Applicative, Monad, MonadState (LiftState thing), MonadTrans)
+  deriving (Functor, Applicative, Monad, MonadState (LiftState thing), MonadTrans, MonadVIX, MonadIO)
 
 freshName :: Monad m => Lift thing m QName
 freshName = do

--- a/src/Frontend/Declassify.hs
+++ b/src/Frontend/Declassify.hs
@@ -58,7 +58,7 @@ declass
     , [(QName, SourceLoc, TopLevelPatDefinition Expr Void, Maybe (Type Void))]
     )
 declass qname loc classDef typ = do
-  modify $ \s -> s
+  liftVIX $ modify $ \s -> s
     { vixClassMethods
       = HashMap.insert qname (Vector.fromList $ methodNames classDef)
       $ vixClassMethods s
@@ -136,7 +136,7 @@ deinstance
   -> VIX [(QName, SourceLoc, TopLevelPatDefinition Expr Void, Maybe (Type Void))]
 deinstance qname@(QName modName name) loc (PatInstanceDef methods) typ = located loc $ do
   className <- getClass typ
-  mnames <- gets $ HashMap.lookup className . vixClassMethods
+  mnames <- liftVIX $ gets $ HashMap.lookup className . vixClassMethods
   case mnames of
     Nothing -> throwInvalidInstance
     Just names -> do

--- a/src/Frontend/ScopeCheck.hs
+++ b/src/Frontend/ScopeCheck.hs
@@ -40,7 +40,7 @@ scopeCheckModule
   :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [[(QName, SourceLoc, Scoped.TopLevelPatDefinition Scoped.Expr void, Maybe (Scoped.Type void))]]
 scopeCheckModule modul = do
-  otherNames <- gets vixModuleNames
+  otherNames <- liftVIX $ gets vixModuleNames
 
   let env = ScopeEnv lookupConstr
       lookupConstr c = MultiHashMap.lookup c constrs

--- a/src/Inference/Class.hs
+++ b/src/Inference/Class.hs
@@ -56,7 +56,7 @@ elabUnsolvedConstraint mkConstraint typ = case typ of
     -- Replace existentials in typ with universals
     (uniType, uniVarMap) <- universalise typ
     -- Try subsumption on all instances of the class until a match is found
-    globalClassInstances <- gets $ HashMap.lookupDefault mempty className . vixClassInstances
+    globalClassInstances <- liftVIX $ gets $ HashMap.lookupDefault mempty className . vixClassInstances
     -- TODO universalise localInstances
     localInstances <- asks constraints
     let candidates = [(Global g, vacuous t) | (g, t) <- globalClassInstances]

--- a/src/Inference/TypeCheck.hs
+++ b/src/Inference/TypeCheck.hs
@@ -4,7 +4,6 @@ module Inference.TypeCheck where
 import Control.Applicative
 import Control.Monad.Except
 import Control.Monad.ST
-import Control.Monad.State
 import Data.Bifunctor
 import Data.Bitraversable
 import Data.Foldable as Foldable
@@ -548,7 +547,7 @@ checkDataType name (DataDef cs) typ = do
 
   mapM_ (unify [] constrRetType) rets
 
-  intRep <- gets $ TypeRep.intRep . vixTarget
+  intRep <- getIntRep
 
   let tagRep = case cs of
         [] -> TypeRep.UnitRep

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -345,6 +345,6 @@ logMeta
   -> f (MetaVar d e)
   -> m ()
 logMeta v s x = whenVerbose v $ do
-  i <- gets vixIndent
+  i <- liftVIX $ gets vixIndent
   r <- showMeta x
   VIX.log $ mconcat (replicate i "| ") <> "--" <> fromString s <> ": " <> showWide r

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -268,7 +268,7 @@ extractExternGroup
   :: [(QName, Sized.Definition Lifted.Expr Void)]
   -> VIX [(QName, Extracted.Submodule (Sized.Definition Extracted.Expr Void))]
 extractExternGroup defs = do
-  target <- gets vixTarget
+  target <- getTarget
   return $
     flip map defs $ \(n, d) -> (n, ExtractExtern.extractDef n d target)
 

--- a/src/Processor/Files.hs
+++ b/src/Processor/Files.hs
@@ -2,7 +2,6 @@
 module Processor.Files where
 
 import Control.Monad.Except
-import Control.Monad.State
 import Data.HashMap.Lazy(HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import qualified Data.HashSet as HashSet
@@ -91,7 +90,7 @@ processBuiltins
   -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [Generate.GeneratedSubmodule]
 processBuiltins builtins1 builtins2 = do
-  tgt <- gets vixTarget
+  tgt <- getTarget
   let context = Builtin.context tgt
   let builtinDefNames = HashSet.fromMap $ void context
       builtinConstrNames = HashSet.fromList

--- a/src/TypedFreeVar.hs
+++ b/src/TypedFreeVar.hs
@@ -65,6 +65,6 @@ logFreeVar
   -> f (FreeVar d)
   -> m ()
 logFreeVar v s x = whenVerbose v $ do
-  i <- gets vixIndent
+  i <- liftVIX $ gets vixIndent
   let r = showFreeVar x
   VIX.log $ mconcat (replicate i "| ") <> "--" <> fromString s <> ": " <> showWide r


### PR DESCRIPTION
This makes it possible for compiler passes to stack State on top of
VIX without having to do a lot of lifting.