### PR TITLE
Support windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
 - stack ${STACK_FLAGS} setup
 
 script:
-- stack test
-- stack test --test-arguments "--sixten-args -O2"
+- stack test --test-arguments "--catch-stderr"
+- stack test --test-arguments "--catch-stderr --sixten-args -O2"
 
 cache:
   directories:

--- a/rts/Builtin2.vix
+++ b/rts/Builtin2.vix
@@ -17,7 +17,13 @@ type String = MkString (Array Byte)
 
 printString : String -> Unit
 printString (MkString (MkArray len data)) = (C|
+#ifdef _WIN32
+  // In MSVC, fd `1` corresponds to `stdout`.
+  // See: https://msdn.microsoft.com/en-us/library/40bbyw78.aspx
+  _write(1, (const void*)$data, $len);
+#else
   write(STDOUT_FILENO, (const void*)$data, $len);
+#endif
 |)
 
 intToNat : Int -> Nat

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -54,8 +54,8 @@ clangBinPath command = trim <$> checkClangExists trySuffixes
           handle (\(_ :: IOException) -> checkClangExists xs)
           $ readProcess (command ++ suffix) ["-print-prog-name=" ++ command ++ suffix] ""
         checkClangExists [] = error (
-          (printf "Couldn't find clang. Currently supported versions are \\
-                  \%d <= v <= %d." minLlvmVersion maxLlvmVersion) :: String)
+          (printf ("Couldn't find clang. Currently supported versions are " <>
+                   "%d <= v <= %d.") minLlvmVersion maxLlvmVersion) :: String)
         trim = dropWhile isSpace . dropWhileEnd isSpace
 
 llvmBinPath :: IO FilePath
@@ -66,9 +66,9 @@ llvmBinPath = checkLlvmExists trySuffixes
           handle (\(_ :: IOException) -> checkLlvmExists xs)
           $ readProcess ("llvm-config" ++ suffix) ["--bindir"] ""
         checkLlvmExists [] = error (
-          (printf "Couldn't find llvm-config. Currently supported versions are \\
-                  \%d <= v <= %d.\n You can specify its path using the \\
-                  \--llvm-config flag." minLlvmVersion maxLlvmVersion) :: String)
+          (printf ("Couldn't find llvm-config. Currently supported versions are " <>
+                   "%d <= v <= %d.\n You can specify its path using the " <>
+                   "--llvm-config flag.") minLlvmVersion maxLlvmVersion) :: String)
 
 compile :: Options -> Arguments -> IO ()
 compile opts args = do

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -81,8 +81,8 @@ compile opts args = do
       if minLlvmVersion <= majorVersion && majorVersion <= maxLlvmVersion then
         readProcess configBin ["--bindir"] ""
       else error (
-          (printf "LLVM version out of range. Currently supported versions are \
-                  \%d <= v <= %d.\n" minLlvmVersion maxLlvmVersion) :: String)
+          (printf ("LLVM version out of range. Currently supported versions are " <>
+                   "%d <= v <= %d.\n") minLlvmVersion maxLlvmVersion) :: String)
   let opt = binPath </> "opt"
   let clang = binPath </> "clang"
   let linker = binPath </> "llvm-link"

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -166,7 +166,7 @@ assemble clang opts objFiles outFile = do
 #else
   -- Currently the bdwgc can only output library linking with dynamic MSVCRT.
   -- however clang will automatically pass static MSVCRT to linker.
-  let ldFlags = "-lgc-lib -Xlinker -nodefaultlib:libcmt -defaultlib:msvcrt.lib"
+  let ldFlags = "-lgc-lib -fuse-ld=lld-link -Xlinker -nodefaultlib:libcmt -Xlinker -defaultlib:msvcrt.lib"
 #endif
   callProcess clang
     $ concatMap words (lines ldFlags)

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -157,9 +157,7 @@ compileLlvm compiler opts tgt llFile = do
 
 assemble :: Binary -> Options -> [FilePath] -> FilePath -> IO ()
 assemble clang opts objFiles outFile = do
-  let extraLibDirFlag = case Options.extraLibDir opts of
-                             Nothing -> ""
-                             Just dir -> "-L" ++ dir
+  let extraLibDirFlag = ["-L" ++ dir | dir <- Options.extraLibDir opts]
 #ifndef mingw32_HOST_OS
   ldFlags <- readProcess "pkg-config" ["--libs", "--static", "bdw-gc"] ""
 #else
@@ -168,6 +166,6 @@ assemble clang opts objFiles outFile = do
   let ldFlags = "-lgc-lib -fuse-ld=lld-link -Xlinker -nodefaultlib:libcmt -Xlinker -defaultlib:msvcrt.lib"
 #endif
   callProcess clang
-    $ concatMap words (extraLibDirFlag : lines ldFlags)
+    $ concatMap words (extraLibDirFlag ++ lines ldFlags)
     ++ optimisationFlags opts
     ++ objFiles ++ ["-o", outFile]

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -171,5 +171,4 @@ assemble clang opts objFiles outFile = do
   callProcess clang
     $ concatMap words (lines ldFlags)
     ++ optimisationFlags opts
-    ++ ["-flto"]
     ++ objFiles ++ ["-o", outFile]

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -161,6 +161,9 @@ compileLlvm compiler opts tgt llFile = do
 
 assemble :: Binary -> Options -> [FilePath] -> FilePath -> IO ()
 assemble clang opts objFiles outFile = do
+  let extraLibDirFlag = case Options.extraLibDir opts of
+                             Nothing -> ""
+                             Just dir -> "-L" ++ dir
 #ifndef mingw32_HOST_OS
   ldFlags <- readProcess "pkg-config" ["--libs", "--static", "bdw-gc"] ""
 #else
@@ -169,6 +172,6 @@ assemble clang opts objFiles outFile = do
   let ldFlags = "-lgc-lib -fuse-ld=lld-link -Xlinker -nodefaultlib:libcmt -Xlinker -defaultlib:msvcrt.lib"
 #endif
   callProcess clang
-    $ concatMap words (lines ldFlags)
+    $ concatMap words (extraLibDirFlag : lines ldFlags)
     ++ optimisationFlags opts
     ++ objFiles ++ ["-o", outFile]

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+{-# LANGUAGE CPP, FlexibleContexts, OverloadedStrings #-}
 module Command.Compile where
 
 import qualified Data.List.NonEmpty as NonEmpty
@@ -108,7 +108,12 @@ compile opts onError onSuccess = case maybe (Right Target.defaultTarget) Target.
       k dir
 
     withOutputFile Nothing k
+#ifndef mingw32_HOST_OS
       = withTempFile firstInputDir firstFileName $ \outputFile outputFileHandle -> do
+#else
+      = withTempFile firstInputDir (firstFileName <> ".exe") $ \outputFile outputFileHandle -> do
+        -- On Windows executable should have suffix @.exe@.
+#endif
         hClose outputFileHandle
         k outputFile
     withOutputFile (Just o) k = do

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -64,7 +64,7 @@ optionsParser = Options
     <> help "Path to the llvm-config binary."
     <> action "file"
     )
-  <*> optional (strOption
+  <*> many (strOption
     $ long "extra-lib-dir"
     <> metavar "DIR"
     <> help "Path where extra libraries (gc-lib.lib, etc.) exist."

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -64,6 +64,12 @@ optionsParser = Options
     <> help "Path to the llvm-config binary."
     <> action "file"
     )
+  <*> optional (strOption
+    $ long "extra-lib-dir"
+    <> metavar "DIR"
+    <> help "Path where extra libraries (gc-lib.lib, etc.) exist."
+    <> action "directory"
+    )
 
 compile
   :: Options

--- a/src/Command/Compile/Options.hs
+++ b/src/Command/Compile/Options.hs
@@ -9,5 +9,5 @@ data Options = Options
   , optimisation :: Maybe String
   , assemblyDir :: Maybe FilePath
   , llvmConfig :: Maybe FilePath
-  , extraLibDir :: Maybe FilePath
+  , extraLibDir :: [FilePath]
   } deriving (Show)

--- a/src/Command/Compile/Options.hs
+++ b/src/Command/Compile/Options.hs
@@ -9,4 +9,5 @@ data Options = Options
   , optimisation :: Maybe String
   , assemblyDir :: Maybe FilePath
   , llvmConfig :: Maybe FilePath
+  , extraLibDir :: Maybe FilePath
   } deriving (Show)

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -317,7 +317,11 @@ writeModule modul llOutputFile externOutputFiles = do
           Text.hPutStrLn handle "#include <stdio.h>"
           Text.hPutStrLn handle "#include <stdlib.h>"
           Text.hPutStrLn handle "#include <string.h>"
+          Text.hPutStrLn handle "#ifdef _WIN32"
+          Text.hPutStrLn handle "#include <io.h>"
+          Text.hPutStrLn handle "#else"
           Text.hPutStrLn handle "#include <unistd.h>"
+          Text.hPutStrLn handle "#endif"
           forM_ externCode $ \code -> do
             Text.hPutStrLn handle ""
             Text.hPutStrLn handle code


### PR DESCRIPTION
+ Use `_write` in printString.
+ Use `<io.h>` on windows instead of `<unistd.h>`.
+ `llvm-config`, `llc`, `opt` and `llvm-link` are not available on windows, use `clang` to compile the LLVM code and link as executable.
