### PR TITLE
Switch to parsix for parsing

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -41,6 +41,7 @@ executable sixten
                        Command.Compile.Options
                        Command.Run
                        Command.Test
+                       Error
                        FreeVar
                        Frontend.Declassify
                        Frontend.Parse
@@ -91,7 +92,6 @@ executable sixten
                        Syntax.Sized.Extracted
                        Syntax.Sized.Lifted
                        Syntax.Sized.SLambda
-                       Syntax.SourceLoc
                        Syntax.Telescope
                        TypeRep
                        TypedFreeVar
@@ -101,7 +101,6 @@ executable sixten
                        Util.TopoSort
                        Util.Tsil
   build-depends:
-                       ansi-wl-pprint,
                        base >=4.8 && <4.11,
                        bifunctors,
                        bound,
@@ -120,6 +119,9 @@ executable sixten
                        multiset,
                        optparse-applicative,
                        parsers,
+                       parsix,
+                       prettyprinter,
+                       prettyprinter-ansi-terminal,
                        process,
                        semigroups,
                        split,
@@ -127,7 +129,6 @@ executable sixten
                        text,
                        transformers,
                        transformers-base,
-                       trifecta,
                        unordered-containers,
                        vector,
                        void

--- a/src/Analysis/ReturnDirection.hs
+++ b/src/Analysis/ReturnDirection.hs
@@ -2,12 +2,12 @@
 module Analysis.ReturnDirection where
 
 import Control.Monad
-import Control.Monad.Except
 import Control.Monad.ST
 import Data.Bitraversable
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe
 import Data.STRef
+import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Vector as Vector
 import Data.Vector(Vector)
 import Data.Void
@@ -85,7 +85,7 @@ unifyMetaReturnIndirect' :: MetaReturnIndirect -> MetaReturnIndirect -> VIX ()
 unifyMetaReturnIndirect' m1 m2 | m1 == m2 = return ()
 unifyMetaReturnIndirect' m (MRef ref2) = liftST $ writeSTRef ref2 $ Just m
 unifyMetaReturnIndirect' (MRef ref1) m = liftST $ writeSTRef ref1 $ Just m
-unifyMetaReturnIndirect' m1 m2 = throwError $ "unifyMetaReturnIndirect " ++ show (m1, m2)
+unifyMetaReturnIndirect' m1 m2 = internalError $ "unifyMetaReturnIndirect" PP.<+> shower (m1, m2)
 
 type Location = MetaReturnIndirect
 
@@ -285,7 +285,7 @@ inferRecursiveDefs defs = do
           $ fromMaybe (error "inferRecursiveDefs 2")
           $ names Vector.!? index
       vf :: MetaVar -> VIX b
-      vf v = throwError $ "inferRecursiveDefs " ++ show v
+      vf v = internalError $ "inferRecursiveDefs" PP.<+> shower v
 
   forM (Vector.zip names genDefs) $ \(name, (def ,sig)) -> do
     let unexposedDef = bound unexpose global def

--- a/src/Backend/Lift.hs
+++ b/src/Backend/Lift.hs
@@ -82,7 +82,7 @@ liftExpr expr = case expr of
   SLambda.Case e brs -> Lifted.Case <$> liftExpr e <*> liftBranches brs
   SLambda.Anno e t -> Lifted.Anno <$> liftExpr e <*> liftExpr t
   SLambda.Lams tele s -> liftLambda tele s
-  SLambda.Lam {} -> throwError "liftExpr Lam"
+  SLambda.Lam {} -> internalError "liftExpr Lam"
   SLambda.ExternCode c -> Lifted.ExternCode <$> mapM liftExpr c
 
 liftLambda
@@ -125,8 +125,8 @@ closeLambda tele lamScope sortedFvs = do
   lamExpr' <- liftExpr lamExpr
   let lamScope' = abstract abstr lamExpr'
 
-  voidedTele <- traverse (const $ throwError "closeLambda") tele''
-  voidedLamScope <- traverse (const $ throwError "closeLambda") lamScope'
+  voidedTele <- traverse (const $ internalError "closeLambda") tele''
+  voidedLamScope <- traverse (const $ internalError "closeLambda") lamScope'
 
   return (voidedTele, voidedLamScope)
 

--- a/src/Backend/Target.hs
+++ b/src/Backend/Target.hs
@@ -4,8 +4,8 @@ module Backend.Target where
 import qualified Data.List as List
 import Data.Monoid
 import Data.Word
-import qualified Text.PrettyPrint.ANSI.Leijen as Leijen
 
+import Error
 import Pretty
 
 -- | The number of bits in a byte.
@@ -46,14 +46,15 @@ targets = [x86, x86_64]
 architectures :: [String]
 architectures = architecture <$> targets
 
-findTarget :: String -> Either Doc Target
+findTarget :: String -> Either Error Target
 findTarget arch = case List.find ((== arch) . architecture) targets of
   Nothing -> Left
-    $ "There is no target architecture called "
-    <> Leijen.red (pretty arch)
-    <> ". Available targets are: "
-    <> prettyHumanList "and" (Leijen.dullgreen . pretty <$> architectures)
-    <> "."
+    $ CommandLineError
+    ("There is no target architecture called " <> red (pretty arch) <> ".")
+    Nothing
+    ("Available targets are: "
+    <> prettyHumanList "and" (dullGreen . pretty <$> architectures)
+    <> ".")
   Just t -> Right t
 
 defaultTarget :: Target

--- a/src/Command/Check.hs
+++ b/src/Command/Check.hs
@@ -2,13 +2,14 @@
 module Command.Check where
 
 import Data.Monoid
-import Options.Applicative
-import Util
-import System.IO
 import qualified Data.Text.IO as Text
+import Options.Applicative
+import System.IO
+import Util
 
 import qualified Backend.Target as Target
 import Command.Check.Options
+import Error
 import qualified Processor.Files as Processor
 import qualified Processor.Result as Processor
 
@@ -42,7 +43,7 @@ optionsParser = Options
 
 check
   :: Options
-  -> ([Processor.Error] -> IO ())
+  -> ([Error] -> IO ())
   -> IO ()
 check opts onError = withLogHandle (logFile opts) $ \logHandle -> do
   procResult <- Processor.checkFiles Processor.Arguments
@@ -62,4 +63,4 @@ check opts onError = withLogHandle (logFile opts) $ \logHandle -> do
 command :: ParserInfo (IO ())
 command = go <$> optionsParserInfo
   where
-    go opts = check opts (mapM_ Processor.printError)
+    go opts = check opts (mapM_ printError)

--- a/src/Command/Compile.hs
+++ b/src/Command/Compile.hs
@@ -12,13 +12,14 @@ import System.IO.Temp
 
 import qualified Backend.Compile as Compile
 import qualified Backend.Target as Target
-import Command.Compile.Options
 import qualified Command.Check as Check
 import qualified Command.Check.Options as Check
+import Command.Compile.Options
+import Error
 import qualified Processor.Files as Processor
 import qualified Processor.Result as Processor
-import Util
 import Syntax.Extern
+import Util
 
 optionsParserInfo :: ParserInfo Options
 optionsParserInfo = info (helper <*> optionsParser)
@@ -66,11 +67,11 @@ optionsParser = Options
 
 compile
   :: Options
-  -> ([Processor.Error] -> IO a)
+  -> ([Error] -> IO a)
   -> (FilePath -> IO a)
   -> IO a
 compile opts onError onSuccess = case maybe (Right Target.defaultTarget) Target.findTarget $ target opts of
-  Left err -> onError $ pure $ Processor.CommandLineError err
+  Left err -> onError $ pure err
   Right tgt ->
     withAssemblyDir (assemblyDir opts) $ \asmDir ->
     withOutputFile (maybeOutputFile opts) $ \outputFile ->
@@ -122,4 +123,4 @@ compile opts onError onSuccess = case maybe (Right Target.defaultTarget) Target.
 command :: ParserInfo (IO ())
 command = go <$> optionsParserInfo
   where
-    go opts = compile opts (mapM_ Processor.printError) (const $ return ())
+    go opts = compile opts (mapM_ printError) (const $ return ())

--- a/src/Command/Run.hs
+++ b/src/Command/Run.hs
@@ -6,7 +6,7 @@ import System.Process
 
 import qualified Command.Compile as Compile
 import qualified Command.Compile.Options as Compile
-import qualified Processor.Result as Processor
+import Error
 
 data Options = Options
   { compileOptions :: Compile.Options
@@ -29,7 +29,7 @@ optionsParser = Options
     )
 
 run :: Options -> IO ()
-run opts = Compile.compile (compileOptions opts) (mapM_ Processor.printError) $ \f ->
+run opts = Compile.compile (compileOptions opts) (mapM_ printError) $ \f ->
   callProcess f $ maybe [] words $ commandLineArguments opts
 
 command :: ParserInfo (IO ())

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings, PatternSynonyms #-}
+module Error where
+
+import Data.Monoid
+import Data.Text(Text)
+import Data.Text.Prettyprint.Doc(line)
+import qualified Data.Text.Prettyprint.Doc as PP
+import Data.Text.Prettyprint.Doc.Render.Terminal
+import Text.Parsix.Highlight
+import Text.Parsix.Position
+
+import Pretty
+import Util
+
+data SourceLoc = SourceLocation
+  { sourceLocFile :: FilePath
+  , sourceLocSpan :: !Span
+  , sourceLocSource :: Text
+  , sourceLocHighlights :: Highlights
+  } deriving (Eq, Ord, Show)
+
+-- | Gives a summary (fileName:row:column) of the location
+instance Pretty SourceLoc where
+  pretty src
+    = pretty (sourceLocFile src)
+    <> ":" <> shower (visualRow loc + 1)
+    <> ":" <> shower (visualColumn loc + 1)
+    where
+      loc = spanStart $ sourceLocSpan src
+
+-- TODO handle spans and not just the start position
+locationRendering :: SourceLoc -> Doc
+locationRendering src = prettyPosition
+  defaultStyle
+  (spanStart $ sourceLocSpan src)
+  (sourceLocSource src)
+  (sourceLocHighlights src)
+
+data ErrorKind
+  = SyntaxErrorKind
+  | TypeErrorKind
+  | CommandLineErrorKind
+  | InternalErrorKind
+  deriving Show
+
+instance Pretty ErrorKind where
+  pretty SyntaxErrorKind = "Syntax error"
+  pretty TypeErrorKind = "Type error"
+  pretty CommandLineErrorKind = "Command-line error"
+  pretty InternalErrorKind = "Internal compiler error"
+
+data Error = Error
+  { errorKind :: !ErrorKind
+  , errorSummary :: !Doc
+  , errorLocation :: !(Maybe SourceLoc)
+  , errorFootnote :: !Doc
+  } deriving Show
+
+{-# COMPLETE SyntaxError, TypeError, CommandLineError, InternalError #-}
+pattern SyntaxError :: Doc -> Maybe SourceLoc -> Doc -> Error
+pattern SyntaxError s l f = Error SyntaxErrorKind s l f
+
+pattern TypeError :: Doc -> Maybe SourceLoc -> Doc -> Error
+pattern TypeError s l f = Error TypeErrorKind s l f
+
+pattern CommandLineError :: Doc -> Maybe SourceLoc -> Doc -> Error
+pattern CommandLineError s l f = Error CommandLineErrorKind s l f
+
+pattern InternalError :: Doc -> Maybe SourceLoc -> Doc -> Error
+pattern InternalError s l f = Error InternalErrorKind s l f
+
+instance Pretty Error where
+  pretty (Error kind summary (Just loc) footnote)
+    = pretty loc <> ":" PP.<+> red (pretty kind) <> ":" PP.<+> summary
+    <> line <> locationRendering loc
+    <> line <> footnote
+    <> line
+  pretty (Error kind summary Nothing footnote)
+    = red (pretty kind) <> ":" <> summary
+    <> line <> footnote
+    <> line
+
+printError :: Error -> IO ()
+printError = putDoc . pretty

--- a/src/Frontend/ScopeCheck.hs
+++ b/src/Frontend/ScopeCheck.hs
@@ -9,6 +9,7 @@ import qualified Data.HashMap.Lazy as HashMap
 import Data.HashMap.Lazy(HashMap)
 import Data.HashSet(HashSet)
 import qualified Data.HashSet as HashSet
+import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Vector as Vector
 
 import qualified Builtin.Names as Builtin
@@ -77,7 +78,7 @@ scopeCheckModule modul = do
       lookupAlias qname
         | HashSet.size candidates == 1 = return $ head $ HashSet.toList candidates
         -- TODO: Error message, duplicate checking, tests
-        | otherwise = throwError $ "scopeCheckModule ambiguous " ++ show candidates
+        | otherwise = throwError $ TypeError ("scopeCheckModule ambiguous" PP.<+> shower candidates) Nothing mempty
         where
           candidates = MultiHashMap.lookupDefault (HashSet.singleton qname) qname aliases
 

--- a/src/Inference/Constructor.hs
+++ b/src/Inference/Constructor.hs
@@ -5,8 +5,7 @@ import Control.Monad.Except
 import qualified Data.HashSet as HashSet
 import Data.HashSet(HashSet)
 import Data.Monoid
-import qualified Text.PrettyPrint.ANSI.Leijen as Leijen
-import Text.Trifecta.Result(Err(Err), explain)
+import qualified Data.Text.Prettyprint.Doc as PP
 
 import Inference.Constraint
 import Inference.Meta
@@ -26,7 +25,7 @@ resolveConstr cs expected = do
   when (HashSet.null cs) $
     err
       "No such data type"
-      ["There is no data type with the" Leijen.<+> constrDoc <> "."]
+      ["There is no data type with the" PP.<+> constrDoc <> "."]
 
   let candidates
         = maybe
@@ -37,15 +36,15 @@ resolveConstr cs expected = do
   case (HashSet.toList candidates, mExpectedTypeName) of
     ([], Just expectedTypeName) ->
       err "Undefined constructor"
-        [ Leijen.dullgreen (pretty expectedTypeName)
-        Leijen.<+> "doesn't define the constructor"
-        Leijen.<+> constrDoc <> "."
+        [ dullGreen (pretty expectedTypeName)
+        PP.<+> "doesn't define the constructor"
+        PP.<+> constrDoc <> "."
         ]
     ([x], _) -> return x
     (xs, _) -> err "Ambiguous constructor"
-      [ "Unable to determine which constructor" Leijen.<+> constrDoc Leijen.<+> "refers to."
+      [ "Unable to determine which constructor" PP.<+> constrDoc PP.<+> "refers to."
       , "Possible candidates:"
-      Leijen.<+> prettyHumanList "and" (Leijen.dullgreen . pretty <$> xs)
+      PP.<+> prettyHumanList "and" (dullGreen . pretty <$> xs)
       <> "."
       ]
   where
@@ -64,13 +63,8 @@ resolveConstr cs expected = do
             DataDefinition _ _ -> Just v
             _ -> Nothing
         _ -> return Nothing
-    err heading docs = do
-      loc <- currentLocation
-      throwError
-        $ show
-        $ explain loc
-        $ Err (Just heading) docs mempty mempty
+    err heading docs = throwLocated $ heading <> PP.line <> PP.vcat docs
     constrDoc = case HashSet.toList cs of
-      (QConstr _ cname:_) -> Leijen.red (pretty cname)
+      (QConstr _ cname:_) -> red (pretty cname)
       _ -> error "resolveConstr no constrs"
 

--- a/src/Inference/Normalise.hs
+++ b/src/Inference/Normalise.hs
@@ -17,7 +17,7 @@ import VIX
 -------------------------------------------------------------------------------
 -- * Weak head normal forms
 whnf
-  :: (MonadIO m, MonadVIX m, MonadError String m, MonadFix m)
+  :: (MonadIO m, MonadVIX m, MonadError Error m, MonadFix m)
   => AbstractM
   -> m AbstractM
 whnf = whnf' WhnfArgs
@@ -26,7 +26,7 @@ whnf = whnf' WhnfArgs
   }
 
 whnfExpandingTypeReps
-  :: (MonadIO m, MonadVIX m, MonadError String m, MonadFix m)
+  :: (MonadIO m, MonadVIX m, MonadError Error m, MonadFix m)
   => AbstractM
   -> m AbstractM
 whnfExpandingTypeReps = whnf' WhnfArgs
@@ -44,7 +44,7 @@ data WhnfArgs m = WhnfArgs
   }
 
 whnf'
-  :: (MonadIO m, MonadVIX m, MonadError String m, MonadFix m)
+  :: (MonadIO m, MonadVIX m, MonadError Error m, MonadFix m)
   => WhnfArgs m
   -> AbstractM
   -> m AbstractM
@@ -83,7 +83,7 @@ whnf' args expr = do
           expr' -> return expr'
 
 whnfInner
-  :: (MonadIO m, MonadVIX m, MonadError String m, MonadFix m)
+  :: (MonadIO m, MonadVIX m, MonadError Error m, MonadFix m)
   => WhnfArgs m
   -> AbstractM
   -> m AbstractM
@@ -113,7 +113,7 @@ whnfInner args expr = case expr of
     <*> whnf' args retType
 
 normalise
-  :: (MonadIO m, MonadVIX m, MonadError String m, MonadFix m)
+  :: (MonadIO m, MonadVIX m, MonadError Error m, MonadFix m)
   => AbstractM
   -> m AbstractM
 normalise expr = do

--- a/src/Processor/Result.hs
+++ b/src/Processor/Result.hs
@@ -1,35 +1,9 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable, OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Processor.Result where
 
 import Control.Monad
-import Data.Monoid as Monoid
 import Data.Semigroup as Semigroup
-import Data.Text(Text)
-import qualified Data.Text.IO as Text
-import System.IO
-import qualified Text.PrettyPrint.ANSI.Leijen as Leijen
-
-data Error
-  = SyntaxError Leijen.Doc
-  | TypeError Text
-  | CommandLineError Leijen.Doc
-  deriving Show
-
-printError :: Error -> IO ()
-printError err = case err of
-  SyntaxError doc -> do
-    Text.putStrLn "Syntax error"
-    Leijen.displayIO stdout
-      $ Leijen.renderPretty 0.8 80
-      $ doc Monoid.<> Leijen.linebreak
-  TypeError s -> do
-    Text.putStrLn "Type error"
-    Text.putStrLn s
-  CommandLineError doc -> do
-    Text.putStrLn "Command-line error"
-    Leijen.displayIO stdout
-      $ Leijen.renderPretty 0.8 80
-      $ doc Monoid.<> Leijen.linebreak
+import Error
 
 data Result a
   = Failure [Error]

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -6,6 +6,7 @@ import Bound.Var as X
 import Control.Monad.Morph as X
 import qualified Util
 
+import Error as X
 import Pretty as X
 import Syntax.Annotation as X
 import Syntax.Branches as X
@@ -15,11 +16,10 @@ import Syntax.Definition as X
 import Syntax.Direction as X
 import Syntax.Extern as X
 import Syntax.GlobalBind as X
-import Syntax.NameHint as X
 import Syntax.Let as X
 import Syntax.Literal as X
 import Syntax.Module as X
 import Syntax.Name as X
+import Syntax.NameHint as X
 import Syntax.Pattern as X
-import Syntax.SourceLoc as X
 import Syntax.Telescope as X

--- a/src/Syntax/Class.hs
+++ b/src/Syntax/Class.hs
@@ -7,11 +7,11 @@ import Control.Monad.Morph
 import Data.Functor.Classes
 import Data.String
 
+import Error
 import Pretty
 import Syntax.Annotation
 import Syntax.GlobalBind
 import Syntax.Name
-import Syntax.SourceLoc
 import Syntax.Telescope
 import Util
 

--- a/src/Syntax/SourceLoc.hs
+++ b/src/Syntax/SourceLoc.hs
@@ -1,6 +1,0 @@
-module Syntax.SourceLoc(delta, render, SourceLoc, Span) where
-
-import Text.Trifecta.Rendering(Rendering, render, Span(..))
-import Text.Trifecta.Delta(delta)
-
-type SourceLoc = Rendering

--- a/src/TypedFreeVar.hs
+++ b/src/TypedFreeVar.hs
@@ -59,7 +59,7 @@ showFreeVar x = do
   pretty (showVar <$> x)
     <> if null shownVars
       then mempty
-      else text ", free vars: " <> pretty shownVars
+      else ", free vars: " <> pretty shownVars
 
 logFreeVar
   :: (Functor d, Functor f, Foldable f, Pretty (f String), Pretty (d String), MonadVIX m, MonadIO m)

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,9 +37,14 @@ resolver: lts-10.0
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
+- location:
+    git: https://github.com/ollef/parsix.git
+    commit: b0e0597ee0947181e40939ab7a77a3b6ba496b21
+  extra-dep: true
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: [llvm-hs-pretty-0.1.0.0]
+extra-deps:
+- llvm-hs-pretty-0.1.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/tests/syntax-error/DataTypeSignature.vix
+++ b/tests/syntax-error/DataTypeSignature.vix
@@ -1,4 +1,3 @@
+Bool : Type
 type Bool where
   False True : Bool
-
-Bool : Type

--- a/tests/type-error/Patterns-TooFewArgs.vix
+++ b/tests/type-error/Patterns-TooFewArgs.vix
@@ -1,3 +1,3 @@
-type List a = Nil | Cons a (Ref (List a))
+type List a = Nil | Cons a (Ptr (List a))
 
 f (Cons z) = 0

--- a/tests/type-error/Patterns-TooManyArgs.vix
+++ b/tests/type-error/Patterns-TooManyArgs.vix
@@ -1,4 +1,4 @@
-type List a = Nil | Cons a (Ref (List a))
+type List a = Nil | Cons a (Ptr (List a))
 
 f (Cons x y z) = 0
 f (Nil x) = 1


### PR DESCRIPTION
And along the way switch to prettyprinter for pretty-printing and clean
up the error handling machinery a bit.

Parsix is a brand new parsing library written to overcome some
limitations of trifecta.

This commit doesn't actually do much but switch out the libraries,
but it opens up for a bright new future where:

* We can have parse error recovery since Parsix supports this
* We commit to using the text library (it's not perfect, but it feels
  better than the previous mixed approach) both when parsing and when
  generating error messages
* We get syntax highlighted error messages (and could emit that info
  for use in editor integration).