### PR TITLE
Remove constructor type argument from Branches

### DIFF
--- a/src/Analysis/Denat.hs
+++ b/src/Analysis/Denat.hs
@@ -24,7 +24,7 @@ denat expr = case expr of
 
 denatCase
   :: Expr v
-  -> Branches QConstr () Expr v
+  -> Branches () Expr v
   -> Expr v
 denatCase expr (ConBranches [ConBranch ZeroConstr _ztele zs, ConBranch SuccConstr _stele ss])
   = let_ mempty expr (global NatName)

--- a/src/Analysis/ReturnDirection.hs
+++ b/src/Analysis/ReturnDirection.hs
@@ -159,8 +159,8 @@ inferCall con _ _ f es = do
 
 inferBranches
   :: Location
-  -> Branches c () Expr MetaVar
-  -> VIX (Branches c () Expr MetaVar, Location)
+  -> Branches () Expr MetaVar
+  -> VIX (Branches () Expr MetaVar, Location)
 inferBranches loc (ConBranches cbrs) = do
   locatedCBrs <- forM cbrs $ \(ConBranch c tele brScope) -> do
     vs <- forMTele tele $ \h _ _ -> exists h loc Nothing

--- a/src/Backend/ClosureConvert.hs
+++ b/src/Backend/ClosureConvert.hs
@@ -220,8 +220,8 @@ knownCall f (tele, returnTypeScope) args
     fArgs = fArgs1 <> fArgs2
 
 convertBranches
-  :: Branches QConstr () Expr FV
-  -> ClosureConvert (Branches QConstr () Expr FV)
+  :: Branches () Expr FV
+  -> ClosureConvert (Branches () Expr FV)
 convertBranches (ConBranches cbrs) = fmap ConBranches $
   forM cbrs $ \(ConBranch qc tele brScope) -> do
     vs <- forMTele tele $ \h () _ ->

--- a/src/Backend/ExtractExtern.hs
+++ b/src/Backend/ExtractExtern.hs
@@ -239,8 +239,8 @@ externType Indirect = "uint8_t*"
 
 extractBranches
   :: Maybe (Extracted.Type FV)
-  -> Branches QConstr () Lifted.Expr FV
-  -> Extract (Branches QConstr () Extracted.Expr FV)
+  -> Branches () Lifted.Expr FV
+  -> Extract (Branches () Extracted.Expr FV)
 extractBranches mtype (ConBranches cbrs) = fmap ConBranches $
   forM cbrs $ \(ConBranch qc tele brScope) -> do
     vs <- forTeleWithPrefixM tele $ \h () s vs -> do

--- a/src/Backend/Generate.hs
+++ b/src/Backend/Generate.hs
@@ -385,7 +385,7 @@ generateGlobal g = do
 
 generateBranches
   :: Expr Var
-  -> Branches QConstr () Expr Var
+  -> Branches () Expr Var
   -> (Expr Var -> InstrGen a)
   -> InstrGen [(a, LLVM.Name)]
 generateBranches caseExpr branches brCont = do

--- a/src/Backend/Lift.hs
+++ b/src/Backend/Lift.hs
@@ -196,8 +196,8 @@ liftLet ds scope = do
   return $ lets sortedDs letBody
 
 liftBranches
-  :: Branches QConstr () SLambda.Expr FV
-  -> LambdaLift (Branches QConstr () Lifted.Expr FV)
+  :: Branches () SLambda.Expr FV
+  -> LambdaLift (Branches () Lifted.Expr FV)
 liftBranches (ConBranches cbrs) = fmap ConBranches $
   forM cbrs $ \(ConBranch qc tele brScope) -> do
     vs <- forTeleWithPrefixM tele $ \h () s vs -> do

--- a/src/Backend/SLam.hs
+++ b/src/Backend/SLam.hs
@@ -84,9 +84,8 @@ slam expr = do
   return res
 
 slamBranches
-  :: Pretty c
-  => Branches c Plicitness Abstract.Expr MetaA
-  -> VIX (Branches c () SLambda.Expr MetaA)
+  :: Branches Plicitness Abstract.Expr MetaA
+  -> VIX (Branches () SLambda.Expr MetaA)
 slamBranches (ConBranches cbrs) = do
   logMeta 20 "slamBranches brs" $ ConBranches cbrs
   modifyIndent succ

--- a/src/Inference/Constraint.hs
+++ b/src/Inference/Constraint.hs
@@ -177,8 +177,8 @@ elabLet mkConstraint ds scope = do
 
 elabBranches
   :: (AbstractM -> Infer AbstractM)
-  -> Branches QConstr Plicitness Expr MetaA
-  -> Infer (Branches QConstr Plicitness Expr MetaA)
+  -> Branches Plicitness Expr MetaA
+  -> Infer (Branches Plicitness Expr MetaA)
 elabBranches mkConstraint (ConBranches cbrs) = do
   cbrs' <- forM cbrs $ \(ConBranch qc tele brScope) -> do
     vs <- forTeleWithPrefixM tele $ \h p s vs -> do

--- a/src/Inference/Meta.hs
+++ b/src/Inference/Meta.hs
@@ -51,7 +51,6 @@ type ConcreteM = Concrete.Expr MetaA
 type AbstractM = Abstract.Expr MetaA
 type LambdaM = SLambda.Expr MetaA
 type ScopeM b f = Scope b f MetaA
-type BranchesM c a f = Branches c a f MetaA
 
 instance Eq (MetaVar d e) where
   (==) = (==) `on` metaId

--- a/src/Inference/Normalise.hs
+++ b/src/Inference/Normalise.hs
@@ -235,7 +235,7 @@ typeRepBinOp lzero rzero op cop norm x y = do
 chooseBranch
   :: Monad m
   => Expr v
-  -> Branches QConstr Plicitness Expr v
+  -> Branches Plicitness Expr v
   -> Expr v
   -> (Expr v -> m (Expr v))
   -> m (Expr v)

--- a/src/Syntax/Abstract.hs
+++ b/src/Syntax/Abstract.hs
@@ -23,7 +23,7 @@ data Expr v
   | Lam !NameHint !Plicitness (Type v) (Scope1 Expr v)
   | App (Expr v) !Plicitness (Expr v)
   | Let (LetRec Expr v) (Scope LetVar Expr v)
-  | Case (Expr v) (Branches QConstr Plicitness Expr v) (Type v)
+  | Case (Expr v) (Branches Plicitness Expr v) (Type v)
   | ExternCode (Extern (Expr v)) (Type v)
   deriving (Foldable, Functor, Traversable)
 

--- a/src/Syntax/Sized/Extracted.hs
+++ b/src/Syntax/Sized/Extracted.hs
@@ -20,7 +20,7 @@ data Expr v
   | Call (Expr v) (Vector (Expr v)) -- ^ Fully applied, only global
   | PrimCall (Maybe Language) RetDir (Expr v) (Vector (Direction, Expr v))
   | Let NameHint (Expr v) (Scope1 Expr v)
-  | Case (Expr v) (Branches QConstr () Expr v)
+  | Case (Expr v) (Branches () Expr v)
   | Anno (Expr v) (Type v)
   deriving (Foldable, Functor, Traversable)
 

--- a/src/Syntax/Sized/Lifted.hs
+++ b/src/Syntax/Sized/Lifted.hs
@@ -20,7 +20,7 @@ data Expr v
   | Call (Expr v) (Vector (Expr v)) -- ^ Fully applied, only global
   | PrimCall RetDir (Expr v) (Vector (Direction, Expr v))
   | Let NameHint (Expr v) (Type v) (Scope1 Expr v)
-  | Case (Expr v) (Branches QConstr () Expr v)
+  | Case (Expr v) (Branches () Expr v)
   | ExternCode (Extern (Expr v))
   | Anno (Expr v) (Type v)
   deriving (Foldable, Functor, Traversable)

--- a/src/Syntax/Sized/SLambda.hs
+++ b/src/Syntax/Sized/SLambda.hs
@@ -20,7 +20,7 @@ data Expr v
   | Lam !NameHint (Type v) (Scope1 Expr v)
   | App (Expr v) (Expr v)
   | Let (LetRec Expr v) (Scope LetVar Expr v)
-  | Case (Expr v) (Branches QConstr () Expr v)
+  | Case (Expr v) (Branches () Expr v)
   | Anno (Expr v) (Type v)
   | ExternCode (Extern (Expr v))
   deriving (Foldable, Functor, Traversable)


### PR DESCRIPTION
This is no longer used at any type other than QConstr, so we might as
well specialise to that.