### PR TITLE
Update to Stackage LTS 10.3

### DIFF
--- a/src/Backend/Generate.hs
+++ b/src/Backend/Generate.hs
@@ -27,9 +27,9 @@ import qualified LLVM.AST.Global as LLVM.Global
 import qualified LLVM.AST.Linkage as LLVM
 import qualified LLVM.AST.Type as LLVM
 import qualified LLVM.AST.Type as LLVM.Type
+import qualified LLVM.AST.Typed as LLVM
 import LLVM.IRBuilder as IRBuilder
 import qualified LLVM.Pretty as LLVM
-import qualified LLVM.Typed as LLVM
 import System.IO
 
 import qualified Backend.ExtractExtern as ExtractExtern
@@ -362,7 +362,7 @@ generateGlobal g = do
   msig <- signature g
   ptrRep <- getPtrRep
   let typ = signatureType $ fromMaybe (ConstantSig Indirect) msig
-      glob = LLVM.GlobalReference (LLVM.ptr typ) $ fromQName g
+      glob = LLVM.GlobalReference typ $ fromQName g
       globOperand = LLVM.ConstantOperand glob
   case msig of
     Just (ConstantSig (Direct TypeRep.UnitRep)) -> return VoidVar
@@ -575,7 +575,7 @@ generateConstant visibility name (Constant e) = do
             Indirect -> indirectType
             Direct TypeRep.UnitRep -> indirectType
             Direct rep -> directType rep
-      let glob = LLVM.GlobalReference (LLVM.ptr typ) gname
+      let glob = LLVM.GlobalReference typ gname
       emitDefn $ LLVM.GlobalDefinition LLVM.globalVariableDefaults
         { LLVM.Global.name = gname
         , LLVM.Global.linkage = linkage
@@ -814,7 +814,7 @@ generateModule mname imports gens = do
       thisInitName = initName mname
       thisInitedName = LLVM.Name $ fromModuleName mname <> "-inited"
       thisInitedOperand
-        = LLVM.ConstantOperand $ LLVM.GlobalReference (LLVM.ptr LLVM.i1) thisInitedName
+        = LLVM.ConstantOperand $ LLVM.GlobalReference LLVM.i1 thisInitedName
       gcInitOperand = LLVM.ConstantOperand $ LLVM.GlobalReference voidFun "GC_init"
       voidFun = LLVM.FunctionType
         { LLVM.resultType = LLVM.void
@@ -877,7 +877,7 @@ generateModule mname imports gens = do
         , LLVM.Constant.isPacked = False
         , LLVM.Constant.memberValues =
           [ LLVM.Int 32 610
-          , LLVM.GlobalReference (LLVM.ptr voidFun) thisInitName
+          , LLVM.GlobalReference voidFun thisInitName
           , LLVM.Null $ LLVM.ptr LLVM.i8
           ]
         }

--- a/src/Backend/Generate/Types.hs
+++ b/src/Backend/Generate/Types.hs
@@ -6,12 +6,12 @@ import Data.Monoid
 import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 import Data.Word
-import LLVM.IRBuilder
 import qualified LLVM.AST as LLVM
 import LLVM.AST.CallingConvention as CC
 import qualified LLVM.AST.Constant as LLVM
 import qualified LLVM.AST.Type as LLVM
-import qualified LLVM.Typed as LLVM
+import qualified LLVM.AST.Typed as LLVM
+import LLVM.IRBuilder
 
 import Backend.Generate.LLVM
 import qualified Backend.Target as Target

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.0
+resolver: lts-10.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -44,7 +44,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- llvm-hs-pretty-0.1.0.0
+- llvm-hs-pretty-0.2.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
And fix some issues that surfaced due to the new version of llvm-hs
handling the type of globals differently.