### PR TITLE
SLambda: Use explicit Anno type

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -88,6 +88,7 @@ executable sixten
                        Syntax.Name
                        Syntax.NameHint
                        Syntax.Pattern
+                       Syntax.Sized.Anno
                        Syntax.Sized.Definition
                        Syntax.Sized.Extracted
                        Syntax.Sized.Lifted

--- a/src/Backend/Lift.hs
+++ b/src/Backend/Lift.hs
@@ -12,11 +12,12 @@ import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 import Data.Void
 
-import TypedFreeVar
 import Syntax
+import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
 import qualified Syntax.Sized.Lifted as Lifted
 import qualified Syntax.Sized.SLambda as SLambda
+import TypedFreeVar
 import Util
 import Util.TopoSort
 import VIX
@@ -76,18 +77,22 @@ liftExpr expr = case expr of
   SLambda.Var v -> return $ Lifted.Var v
   SLambda.Global g -> return $ Lifted.Global g
   SLambda.Lit l -> return $ Lifted.Lit l
-  SLambda.Con qc es -> Lifted.Con qc <$> mapM liftExpr es
-  SLambda.App e1 e2 -> Lifted.Call <$> liftExpr e1 <*> (pure <$> liftExpr e2)
+  SLambda.Con qc es -> Lifted.Con qc <$> mapM liftAnnoExpr es
+  SLambda.App e1 e2 -> Lifted.Call <$> liftExpr e1 <*> (pure <$> liftAnnoExpr e2)
   SLambda.Let ds scope -> liftLet ds scope
-  SLambda.Case e brs -> Lifted.Case <$> liftExpr e <*> liftBranches brs
-  SLambda.Anno e t -> Lifted.Anno <$> liftExpr e <*> liftExpr t
+  SLambda.Case e brs -> Lifted.Case <$> liftAnnoExpr e <*> liftBranches brs
   SLambda.Lams tele s -> liftLambda tele s
   SLambda.Lam {} -> internalError "liftExpr Lam"
-  SLambda.ExternCode c -> Lifted.ExternCode <$> mapM liftExpr c
+  SLambda.ExternCode c retType -> Lifted.ExternCode <$> mapM liftAnnoExpr c <*> liftExpr retType
+
+liftAnnoExpr
+  :: Anno SLambda.Expr FV
+  -> LambdaLift (Anno Lifted.Expr FV)
+liftAnnoExpr (Anno e t) = Anno <$> liftExpr e <*> liftExpr t
 
 liftLambda
   :: Telescope () SLambda.Expr FV
-  -> Scope TeleVar SLambda.Expr FV
+  -> AnnoScope TeleVar SLambda.Expr FV
   -> LambdaLift (Lifted.Expr FV)
 liftLambda tele lamScope = do
   logFreeVar 20 "liftLambda" $ Sized.Function tele lamScope
@@ -96,7 +101,7 @@ liftLambda tele lamScope = do
 
   (closedTele, closedLamScope) <- closeLambda tele lamScope sortedFvs
 
-  let args = (\v -> Lifted.Anno (pure v) (varType v)) <$> sortedFvs
+  let args = (\v -> Anno (pure v) (varType v)) <$> sortedFvs
       addArgs | null args = id
               | otherwise = (`Lifted.Call` args)
 
@@ -108,22 +113,22 @@ liftLambda tele lamScope = do
 
 closeLambda
   :: Telescope () SLambda.Expr FV
-  -> Scope TeleVar SLambda.Expr FV
+  -> AnnoScope TeleVar SLambda.Expr FV
   -> Vector FV
-  -> LambdaLift (Telescope () Lifted.Expr Void, Scope TeleVar Lifted.Expr Void)
+  -> LambdaLift (Telescope () Lifted.Expr Void, AnnoScope TeleVar Lifted.Expr Void)
 closeLambda tele lamScope sortedFvs = do
   vs <- forTeleWithPrefixM tele $ \h () s vs -> do
     let e = instantiateTele pure vs s
     e' <- liftExpr e
     freeVar h e'
 
-  let lamExpr = instantiateTele pure vs lamScope
+  let lamExpr = instantiateAnnoTele pure vs lamScope
       vs' = sortedFvs <> vs
       abstr = teleAbstraction vs'
       tele'' = Telescope $ (\v -> TeleArg (varHint v) () $ abstract abstr $ varType v) <$> vs'
 
-  lamExpr' <- liftExpr lamExpr
-  let lamScope' = abstract abstr lamExpr'
+  lamExpr' <- liftAnnoExpr lamExpr
+  let lamScope' = abstractAnno abstr lamExpr'
 
   voidedTele <- traverse (const $ internalError "closeLambda") tele''
   voidedLamScope <- traverse (const $ internalError "closeLambda") lamScope'
@@ -156,7 +161,7 @@ liftLet ds scope = do
       liftedVars = toHashSet $ fst <$> dsToLift
       fvs = fold (toHashSet . snd <$> dsToLift) `HashSet.difference` liftedVars
       sortedFvs = topoSortVars fvs
-      args = (\v -> Lifted.Anno (pure v) (varType v)) <$> sortedFvs
+      args = (\v -> Anno (pure v) (varType v)) <$> sortedFvs
       addArgs | null args = id
               | otherwise = (`Lifted.Call` args)
 
@@ -219,31 +224,31 @@ lets
   -> Lifted.Expr FV
 lets = flip $ foldr go
   where
-    go [(v, e)] = Lifted.Let (varHint v) e (varType v) . abstract1 v
+    go [(v, e)] = Lifted.Let (varHint v) (Anno e $ varType v) . abstract1 v
     go _ = error "Circular Lift lets"
 
 liftToDefinitionM
-  :: SLambda.Expr Void
+  :: Anno SLambda.Expr Void
   -> LambdaLift (Sized.Definition Lifted.Expr Void)
-liftToDefinitionM (SLambda.Anno (SLambda.Lams tele bodyScope) _) = do
+liftToDefinitionM (Anno (SLambda.Lams tele bodyScope) _) = do
   vs <- forTeleWithPrefixM tele $ \h () s vs -> do
     let e = instantiateTele pure vs $ vacuous s
     e' <- liftExpr e
     freeVar h e'
-  let body = instantiateTele pure vs $ vacuous bodyScope
+  let body = instantiateAnnoTele pure vs $ vacuous bodyScope
       abstr = teleAbstraction vs
       tele' = Telescope $ (\v -> TeleArg (varHint v) () $ abstract abstr $ varType v) <$> vs
-  body' <- liftExpr body
-  let bodyScope' = abstract abstr body'
+  body' <- liftAnnoExpr body
+  let bodyScope' = abstractAnno abstr body'
   return $ Sized.FunctionDef Public Sized.NonClosure $ (\_ -> error "liftToDefinitionM") <$> Sized.Function tele' bodyScope'
 liftToDefinitionM sexpr = do
-  sexpr' <- liftExpr $ vacuous sexpr
+  sexpr' <- liftAnnoExpr $ vacuous sexpr
   logFreeVar 20 "liftToDefinitionM sexpr'" sexpr'
   return $ Sized.ConstantDef Public $ Sized.Constant $ (\_ -> error "liftToDefinitionM 2") <$> sexpr'
 
 liftToDefinition
   :: QName
-  -> SLambda.Expr Void
+  -> Anno SLambda.Expr Void
   -> VIX (Sized.Definition Lifted.Expr Void, [(QName, Sized.Function Lifted.Expr Void)])
 liftToDefinition (QName mname name) expr
   = runLift (QName mname $ name <> "-lifted") (liftToDefinitionM expr)

--- a/src/Backend/SLam.hs
+++ b/src/Backend/SLam.hs
@@ -13,12 +13,13 @@ import Inference.Normalise
 import Inference.TypeOf
 import Syntax
 import qualified Syntax.Abstract as Abstract
+import Syntax.Sized.Anno
 import qualified Syntax.Sized.SLambda as SLambda
 import Util
 import VIX
 
-slamSized :: AbstractM -> VIX LambdaM
-slamSized e = SLambda.Anno <$> slam e <*> (slam =<< whnfExpandingTypeReps =<< typeOf e)
+slamAnno :: AbstractM -> VIX (Anno SLambda.Expr MetaA)
+slamAnno e = Anno <$> slam e <*> (slam =<< whnfExpandingTypeReps =<< typeOf e)
 
 slam :: AbstractM -> VIX LambdaM
 slam expr = do
@@ -39,9 +40,9 @@ slam expr = do
     Abstract.Lam h p t s -> do
       t' <- whnfExpandingTypeReps t
       v <- forall h p t'
-      e <- slamSized $ instantiate1 (pure v) s
+      e <- slamAnno $ instantiate1 (pure v) s
       rep <- slam t'
-      return $ SLambda.Lam h rep $ abstract1 v e
+      return $ SLambda.Lam h rep $ abstract1Anno v e
     (Abstract.appsView -> (Abstract.Con qc@(QConstr typeName _), es)) -> do
       (_, typeType) <- definition typeName
       n <- constrArity qc
@@ -50,7 +51,7 @@ slam expr = do
         EQ -> do
           let numParams = teleLength $ Abstract.telescope typeType
               es' = drop numParams es
-          SLambda.Con qc <$> mapM slamSized (Vector.fromList $ snd <$> es')
+          SLambda.Con qc <$> mapM slamAnno (Vector.fromList $ snd <$> es')
         LT -> do
           conType <- qconstructor qc
           let Just appliedConType = Abstract.typeApps conType $ snd <$> es
@@ -62,22 +63,22 @@ slam expr = do
             $ Vector.fromList (fmap (pure . pure) <$> es)
             <> iforTele tele (\i _ a _ -> (a, pure $ B $ TeleVar i))
     Abstract.Con _qc -> internalError "slam impossible"
-    Abstract.App e1 _ e2 -> SLambda.App <$> slam e1 <*> slamSized e2
-    Abstract.Case e brs _retType -> SLambda.Case <$> slamSized e <*> slamBranches brs
+    Abstract.App e1 _ e2 -> SLambda.App <$> slam e1 <*> slamAnno e2
+    Abstract.Case e brs _retType -> SLambda.Case <$> slamAnno e <*> slamBranches brs
     Abstract.Let ds scope -> do
       vs <- forMLet ds $ \h _ t -> forall h Explicit t
       let abstr = letAbstraction vs
       ds' <- fmap LetRec $ forMLet ds $ \h s t -> do
-        e <- slamSized $ instantiateLet pure vs s
+        e <- slam $ instantiateLet pure vs s
         t' <- slam t
         return $ LetBinding h (abstract abstr e) t'
-      body <- slamSized $ instantiateLet pure vs scope
+      body <- slam $ instantiateLet pure vs scope
       let scope' = abstract abstr body
       return $ SLambda.Let ds' scope'
     Abstract.ExternCode c retType -> do
         retType' <- slam =<< whnfExpandingTypeReps retType
         c' <- slamExtern c
-        return $ SLambda.Anno (SLambda.ExternCode c') retType'
+        return $ SLambda.ExternCode c' retType'
   logMeta 20 "slam res" res
   return res
 
@@ -110,16 +111,16 @@ slamBranches (LitBranches lbrs d)
 
 slamExtern
   :: Extern (Abstract.Expr MetaA)
-  -> VIX (Extern (SLambda.Expr MetaA))
+  -> VIX (Extern (Anno SLambda.Expr MetaA))
 slamExtern (Extern lang parts)
   = fmap (Extern lang) $ forM parts $ \part -> case part of
     ExternPart str -> return $ ExternPart str
-    ExprMacroPart e -> ExprMacroPart <$> slamSized e
-    TypeMacroPart t -> TypeMacroPart <$> (slam =<< whnfExpandingTypeReps t)
+    ExprMacroPart e -> ExprMacroPart <$> slamAnno e
+    TypeMacroPart t -> TypeMacroPart <$> (slamAnno =<< whnfExpandingTypeReps t)
     TargetMacroPart m -> return $ TargetMacroPart m
 
 slamDef
   :: Definition Abstract.Expr MetaA
-  -> VIX LambdaM
-slamDef (Definition _ _ e) = slamSized e
-slamDef (DataDefinition _ e) = slamSized e
+  -> VIX (Anno SLambda.Expr MetaA)
+slamDef (Definition _ _ e) = slamAnno e
+slamDef (DataDefinition _ e) = slamAnno e

--- a/src/Builtin.hs
+++ b/src/Builtin.hs
@@ -16,6 +16,7 @@ import Backend.Target(Target)
 import Builtin.Names
 import Syntax
 import Syntax.Abstract as Abstract
+import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
 import qualified Syntax.Sized.Lifted as Lifted
 import qualified TypeRep
@@ -59,26 +60,23 @@ convertedContext target = HashMap.fromList $ concat
 
 convertedSignatures :: Target -> HashMap QName Lifted.FunSignature
 convertedSignatures target
-  = flip HashMap.mapMaybeWithKey (convertedContext target) $ \name def ->
+  = flip HashMap.mapMaybe (convertedContext target) $ \def ->
     case def of
-      Sized.FunctionDef _ _ (Sized.Function tele s) -> case fromScope s of
-        Lifted.Anno _ t -> Just (tele, toScope t)
-        _ -> error $ "Sixten.Builtin.convertedSignatures " <> show name
+      Sized.FunctionDef _ _ (Sized.Function tele (AnnoScope _ s)) -> Just (tele, s)
       Sized.ConstantDef _ _ -> Nothing
       Sized.AliasDef -> Nothing
 
-deref :: Target -> Lifted.Expr v -> Lifted.Expr v
-deref target e
-  = Lifted.Case (Lifted.Sized intRep e)
+deref :: Lifted.Expr v -> Lifted.Expr v
+deref e
+  = Lifted.Case (Anno e unknownSize)
   $ ConBranches
   $ pure
   $ ConBranch
     Ref
     (Telescope $ pure $ TeleArg "dereferenced" () $ Scope unknownSize)
-    (toScope $ Lifted.Var $ B 0)
+    (toScope $ pure $ B 0)
   where
-    unknownSize = global "Sixten.Builtin.deref.UnknownSize"
-    intRep = Lifted.MkType $ TypeRep.intRep target
+    unknownSize = global "Sixten.Builtin.deref.unknownSize"
 
 maxArity :: Num n => n
 maxArity = 6
@@ -91,9 +89,9 @@ apply target numArgs
     $ Vector.cons (TeleArg "this" () $ Scope ptrRep)
     $ (\n -> TeleArg (fromText $ "type" <> shower (unTeleVar n)) () $ Scope typeRep) <$> Vector.enumFromN 0 numArgs
     <|> (\n -> TeleArg (fromText $ "x" <> shower (unTeleVar n)) () $ Scope $ pure $ B $ 1 + n) <$> Vector.enumFromN 0 numArgs)
-  $ toScope
-  $ Lifted.Sized (Lifted.Global "Sixten.Builtin.apply.unknownSize")
-  $ Lifted.Case (deref target $ Lifted.Var $ B 0)
+  $ toAnnoScope
+  $ flip Anno unknownSize
+  $ Lifted.Case (Anno (deref $ pure $ B 0) unknownSize)
   $ ConBranches
   $ pure
   $ ConBranch
@@ -101,15 +99,16 @@ apply target numArgs
     (Telescope $ Vector.fromList
       [TeleArg "f_unknown" () $ Scope ptrRep, TeleArg "n" () $ Scope intRep])
     (toScope
-      $ Lifted.Case (Lifted.Sized intRep $ Lifted.Var $ B 1)
+      $ Lifted.Case (Anno (pure $ B 1) unknownSize)
       $ LitBranches
         [LitBranch (Integer $ fromIntegral arity) $ br arity | arity <- 1 :| [2..maxArity]]
-        $ Lifted.Call (global FailName) $ pure $ Lifted.Sized typeRep unitRep)
+        $ Lifted.Call (global FailName) $ pure $ Anno unitRep typeRep)
   where
     unitRep = Lifted.MkType TypeRep.UnitRep
     intRep = Lifted.MkType $ TypeRep.intRep target
     ptrRep = Lifted.MkType $ TypeRep.ptrRep target
     typeRep = Lifted.MkType $ TypeRep.typeRep target
+    unknownSize = global "Sixten.Builtin.apply.unknownSize"
 
     directPtr = Direct $ TypeRep.ptrRep target
     directType = Direct $ TypeRep.typeRep target
@@ -120,26 +119,26 @@ apply target numArgs
         = Lifted.Con Ref
         $ pure
         $ sizedCon target (Lifted.MkType TypeRep.UnitRep) Closure
-        $ Vector.cons (Lifted.Sized ptrRep $ global $ papName (arity - numArgs) numArgs)
-        $ Vector.cons (Lifted.Sized intRep $ Lifted.Lit $ Integer $ fromIntegral $ arity - numArgs)
-        $ Vector.cons (Lifted.Sized ptrRep $ Lifted.Var $ F $ B 0)
-        $ (\n -> Lifted.Sized typeRep $ Lifted.Var $ F $ B $ 1 + n) <$> Vector.enumFromN 0 numArgs
-        <|> (\n -> Lifted.Sized (Lifted.Var $ F $ B $ 1 + n) $ Lifted.Var $ F $ B $ 1 + TeleVar numArgs + n) <$> Vector.enumFromN 0 numArgs
+        $ Vector.cons (Anno (global $ papName (arity - numArgs) numArgs) ptrRep)
+        $ Vector.cons (Anno (Lifted.Lit $ Integer $ fromIntegral $ arity - numArgs) intRep)
+        $ Vector.cons (Anno (pure $ F $ B 0) ptrRep)
+        $ (\n -> Anno (pure $ F $ B $ 1 + n) typeRep) <$> Vector.enumFromN 0 numArgs
+        <|> (\n -> Anno (pure $ F $ B $ 1 + TeleVar numArgs + n) (pure $ F $ B $ 1 + n)) <$> Vector.enumFromN 0 numArgs
       | numArgs == arity
-        = Lifted.PrimCall (ReturnIndirect OutParam) (Lifted.Var $ B 0)
-        $ Vector.cons (directPtr, Lifted.Sized ptrRep $ Lifted.Var $ F $ B 0)
-        $ (\n -> (directType, Lifted.Sized typeRep $ Lifted.Var $ F $ B $ 1 + n)) <$> Vector.enumFromN 0 numArgs
-        <|> (\n -> (Indirect, Lifted.Sized (Lifted.Var $ F $ B $ 1 + n) $ Lifted.Var $ F $ B $ 1 + TeleVar numArgs + n)) <$> Vector.enumFromN 0 numArgs
+        = Lifted.PrimCall (ReturnIndirect OutParam) (pure $ B 0)
+        $ Vector.cons (directPtr, Anno (pure $ F $ B 0) ptrRep)
+        $ (\n -> (directType, Anno (pure $ F $ B $ 1 + n) typeRep)) <$> Vector.enumFromN 0 numArgs
+        <|> (\n -> (Indirect, Anno (pure $ F $ B $ 1 + TeleVar numArgs + n) (pure $ F $ B $ 1 + n))) <$> Vector.enumFromN 0 numArgs
       | otherwise
         = Lifted.Call (global $ applyName $ numArgs - arity)
         $ Vector.cons
-          (Lifted.Sized ptrRep
-          $ Lifted.PrimCall (ReturnIndirect OutParam) (Lifted.Var $ B 0)
-          $ Vector.cons (directPtr, Lifted.Sized ptrRep $ Lifted.Var $ F $ B 0)
-          $ (\n -> (directType, Lifted.Sized typeRep $ Lifted.Var $ F $ B $ 1 + n)) <$> Vector.enumFromN 0 arity
-          <|> (\n -> (Indirect, Lifted.Sized (Lifted.Var $ F $ B $ 1 + n) $ Lifted.Var $ F $ B $ 1 + fromIntegral numArgs + n)) <$> Vector.enumFromN 0 arity)
-        $ (\n -> Lifted.Sized typeRep $ Lifted.Var $ F $ B $ 1 + n) <$> Vector.enumFromN (fromIntegral arity) (numArgs - arity)
-        <|> (\n -> Lifted.Sized (Lifted.Var $ F $ B $ 1 + n) $ Lifted.Var $ F $ B $ 1 + fromIntegral numArgs + n) <$> Vector.enumFromN (fromIntegral arity) (numArgs - arity)
+          (flip Anno ptrRep
+          $ Lifted.PrimCall (ReturnIndirect OutParam) (pure $ B 0)
+          $ Vector.cons (directPtr, Anno (pure $ F $ B 0) ptrRep)
+          $ (\n -> (directType, Anno (pure $ F $ B $ 1 + n) typeRep)) <$> Vector.enumFromN 0 arity
+          <|> (\n -> (Indirect, Anno (pure $ F $ B $ 1 + fromIntegral numArgs + n) (pure $ F $ B $ 1 + n))) <$> Vector.enumFromN 0 arity)
+        $ (\n -> Anno (pure $ F $ B $ 1 + n) typeRep) <$> Vector.enumFromN (fromIntegral arity) (numArgs - arity)
+        <|> (\n -> Anno (pure $ F $ B $ 1 + fromIntegral numArgs + n) (pure $ F $ B $ 1 + n)) <$> Vector.enumFromN (fromIntegral arity) (numArgs - arity)
 
 pap :: Target -> Int -> Int -> Sized.Definition Lifted.Expr Void
 pap target k m
@@ -149,9 +148,9 @@ pap target k m
     $ Vector.cons (TeleArg "this" () $ Scope ptrRep)
     $ (\n -> TeleArg (fromText $ "type" <> shower (unTeleVar n)) () $ Scope typeRep) <$> Vector.enumFromN 0 k
     <|> (\n -> TeleArg (fromText $ "x" <> shower (unTeleVar n)) () $ Scope $ pure $ B $ 1 + n) <$> Vector.enumFromN 0 k)
-  $ toScope
-  $ Lifted.Sized (Lifted.Global "Sixten.Builtin.pap.unknownSize")
-  $ Lifted.Case (deref target $ Lifted.Var $ B 0)
+  $ toAnnoScope
+  $ flip Anno unknownSize
+  $ Lifted.Case (Anno (deref $ pure $ B 0) unknownSize)
   $ ConBranches
   $ pure
   $ ConBranch
@@ -164,22 +163,23 @@ pap target k m
       <|> (\n -> TeleArg (fromText $ "y" <> shower (unTeleVar n)) () $ Scope $ pure $ B $ 3 + n) <$> Vector.enumFromN 0 m)
     (toScope
       $ Lifted.Call (global $ applyName $ m + k)
-      $ Vector.cons (Lifted.Sized ptrRep $ Lifted.Var $ B 2)
-      $ (\n -> Lifted.Sized typeRep $ Lifted.Var $ B $ 3 + n) <$> Vector.enumFromN 0 m
-      <|> (\n -> Lifted.Sized typeRep $ Lifted.Var $ F $ B $ 1 + n) <$> Vector.enumFromN 0 k
-      <|> (\n -> Lifted.Sized (Lifted.Var $ B $ 3 + n) $ Lifted.Var $ B $ 3 + TeleVar m + n) <$> Vector.enumFromN 0 m
-      <|> (\n -> Lifted.Sized (Lifted.Var $ F $ B $ 1 + n) $ Lifted.Var $ F $ B $ 1 + TeleVar k + n) <$> Vector.enumFromN 0 k
+      $ Vector.cons (Anno (pure $ B 2) ptrRep)
+      $ (\n -> Anno (pure $ B $ 3 + n) typeRep) <$> Vector.enumFromN 0 m
+      <|> (\n -> Anno (pure $ F $ B $ 1 + n) typeRep) <$> Vector.enumFromN 0 k
+      <|> (\n -> Anno (pure $ B $ 3 + TeleVar m + n) (pure $ B $ 3 + n)) <$> Vector.enumFromN 0 m
+      <|> (\n -> Anno (pure $ F $ B $ 1 + TeleVar k + n) (pure $ F $ B $ 1 + n)) <$> Vector.enumFromN 0 k
     )
   where
+    unknownSize = global "Sixten.Builtin.pap.unknownSize"
     intRep = Lifted.MkType $ TypeRep.intRep target
     ptrRep = Lifted.MkType $ TypeRep.ptrRep target
     typeRep = Lifted.MkType $ TypeRep.typeRep target
 
-sizedCon :: Target -> Lifted.Expr v -> QConstr -> Vector (Lifted.Expr v) -> Lifted.Expr v
+sizedCon :: Target -> Lifted.Expr v -> QConstr -> Vector (Anno Lifted.Expr v) -> Anno Lifted.Expr v
 sizedCon target tagRep qc args
-  = Lifted.Sized (productTypes target $ Vector.cons tagRep argTypes) (Lifted.Con qc args)
+  = Anno (Lifted.Con qc args) (productTypes target $ Vector.cons tagRep argTypes)
   where
-    argTypes = Lifted.typeOf <$> args
+    argTypes = typeAnno <$> args
 
 productType :: Target -> Lifted.Expr v -> Lifted.Expr v -> Lifted.Expr v
 productType _ a (Lifted.MkType TypeRep.UnitRep) = a
@@ -187,7 +187,7 @@ productType _ (Lifted.MkType TypeRep.UnitRep) b = b
 productType _ (Lifted.MkType rep1) (Lifted.MkType rep2) = Lifted.MkType $ TypeRep.product rep1 rep2
 productType target a b
   = Lifted.Call (global ProductTypeRepName)
-  $ Vector.fromList [Lifted.Anno a (Lifted.MkType typeRep), Lifted.Anno b (Lifted.MkType typeRep)]
+  $ Vector.fromList [Anno a (Lifted.MkType typeRep), Anno b (Lifted.MkType typeRep)]
   where
      typeRep = TypeRep.typeRep target
 

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -37,6 +37,7 @@ import Syntax
 import qualified Syntax.Abstract as Abstract
 import qualified Syntax.Concrete.Scoped as Concrete
 import qualified Syntax.Concrete.Unscoped as Unscoped
+import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
 import qualified Syntax.Sized.Extracted as Extracted
 import qualified Syntax.Sized.Lifted as Lifted
@@ -232,19 +233,19 @@ addGroupToContext defs = do
 
 slamGroup
   :: [(QName, Definition Abstract.Expr Void, Abstract.Expr Void)]
-  -> VIX [(QName, SLambda.Expr Void)]
+  -> VIX [(QName, Anno SLambda.Expr Void)]
 slamGroup defs = forM defs $ \(x, d, _t) -> do
   d' <- SLam.slamDef $ vacuous d
   d'' <- traverse (internalError . ("slamGroup" PP.<+>) . shower) d'
   return (x, d'')
 
 denatGroup
-  :: [(QName, SLambda.Expr Void)]
-  -> VIX [(QName, SLambda.Expr Void)]
-denatGroup defs = return [(n, denat def) | (n, def) <- defs]
+  :: [(QName, Anno SLambda.Expr Void)]
+  -> VIX [(QName, Anno SLambda.Expr Void)]
+denatGroup defs = return [(n, denatAnno def) | (n, def) <- defs]
 
 liftGroup
-  :: [(QName, SLambda.Expr Void)]
+  :: [(QName, Anno SLambda.Expr Void)]
   -> VIX [[(QName, Sized.Definition Lifted.Expr Void)]]
 liftGroup defs = fmap (Sized.dependencyOrder . concat) $ forM defs $ \(name, e) -> do
   (e', fs) <- liftToDefinition name e

--- a/src/Syntax/Sized/Anno.hs
+++ b/src/Syntax/Sized/Anno.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+module Syntax.Sized.Anno where
+
+import Bound
+import Bound.Scope
+import Data.Deriving
+import Data.Functor.Classes
+import Data.Maybe
+import Data.Monoid
+import Data.Vector(Vector)
+import qualified Data.Vector as Vector
+
+import Syntax
+import Util
+
+data Anno e v = Anno (e v) (e v)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+typeAnno :: Anno e v -> e v
+typeAnno (Anno _ t) = t
+
+data AnnoScope b e a = AnnoScope (Scope b e a) (Scope b e a)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+type AnnoScope1 = AnnoScope ()
+
+toAnnoScope :: Monad e => Anno e (Var b a) -> AnnoScope b e a
+toAnnoScope (Anno e t) = AnnoScope (toScope e) (toScope t)
+
+fromAnnoScope :: Monad e => AnnoScope b e a -> Anno e (Var b a)
+fromAnnoScope (AnnoScope se st) = Anno (fromScope se) (fromScope st)
+
+instantiateAnno :: Monad e => (b -> e a) -> AnnoScope b e a -> Anno e a
+instantiateAnno f (AnnoScope se st) = Anno (instantiate f se) (instantiate f st)
+
+instantiate1Anno :: Monad e => e a -> AnnoScope1 e a -> Anno e a
+instantiate1Anno x (AnnoScope se st) = Anno (Util.instantiate1 x se) (Util.instantiate1 x st)
+
+abstractAnno :: Monad e => (a -> Maybe b) -> Anno e a -> AnnoScope b e a
+abstractAnno f (Anno e t) = AnnoScope (abstract f e) (abstract f t)
+
+abstract1Anno :: (Monad e, Eq a) => a -> Anno e a -> AnnoScope1 e a
+abstract1Anno a (Anno e t) = AnnoScope (abstract1 a e) (abstract1 a t)
+
+instantiateAnnoLet
+  :: Monad f
+  => (v -> f a)
+  -> Vector v
+  -> AnnoScope LetVar f a
+  -> Anno f a
+instantiateAnnoLet f vs
+  = instantiateAnno (f . fromMaybe (error "instantiateAnnoLet") . (vs Vector.!?) . unLetVar)
+
+mapAnnoBound :: Functor e => (b -> b') -> AnnoScope b e a -> AnnoScope b' e a
+mapAnnoBound f (AnnoScope s s') = AnnoScope (mapBound f s) (mapBound f s')
+
+annoBindingsViewM
+  :: (Monad expr, Monad expr')
+  => (forall v'. expr' v' -> Maybe (NameHint, a, expr v', AnnoScope1 expr' v'))
+  -> expr' v
+  -> Maybe (Telescope a expr v, AnnoScope TeleVar expr' v)
+annoBindingsViewM f expr@(f -> Just _) = Just $ annoBindingsView f $ Anno expr $ error "annoBindingsViewM"
+annoBindingsViewM _ _ = Nothing
+
+-- | View consecutive bindings at the same time
+annoBindingsView
+  :: (Monad expr, Monad expr')
+  => (forall v'. expr' v' -> Maybe (NameHint, a, expr v', AnnoScope1 expr' v'))
+  -> Anno expr' v
+  -> (Telescope a expr v, AnnoScope TeleVar expr' v)
+annoBindingsView f expr = go 0 $ F <$> expr
+  where
+    go x (Anno (f -> Just (n, p, e, s)) _) = (Telescope $ pure (TeleArg n p $ toScope e) <> ns, s')
+      where
+        (Telescope ns, s') = (go $! x + 1) $ instantiate1Anno (return $ B x) s
+    go _ e = (Telescope mempty, toAnnoScope e)
+
+instantiateAnnoTele
+  :: Monad f
+  => (v -> f a)
+  -> Vector v
+  -> AnnoScope TeleVar f a
+  -> Anno f a
+instantiateAnnoTele f vs
+  = instantiateAnno (f . fromMaybe (error "instantiateAnnoTele") . (vs Vector.!?) . unTeleVar)
+
+-------------------------------------------------------------------------------
+-- Instances
+deriveEq1 ''Anno
+deriveOrd1 ''Anno
+deriveShow1 ''Anno
+
+instance MFunctor Anno where
+  hoist f (Anno e t) = Anno (f e) (f t)
+
+instance MFunctor (AnnoScope b) where
+  hoist f (AnnoScope s t) = AnnoScope (hoist f s) (hoist f t)
+
+instance GlobalBound Anno where
+  bound f g (Anno e t) = Anno (bind f g e) (bind f g t)
+
+instance GlobalBound (AnnoScope b) where
+  bound f g (AnnoScope e t) = AnnoScope (bound f g e) (bound f g t)
+
+instance (Eq b, Eq1 expr, Monad expr) => Eq1 (AnnoScope b expr) where
+  liftEq = $(makeLiftEq ''AnnoScope)
+
+instance (Ord b, Ord1 expr, Monad expr) => Ord1 (AnnoScope b expr) where
+  liftCompare = $(makeLiftCompare ''AnnoScope)
+
+instance (Show b, Show1 expr, Monad expr) => Show1 (AnnoScope b expr) where
+  liftShowsPrec = $(makeLiftShowsPrec ''AnnoScope)
+
+instance Pretty (e v) => Pretty (Anno e v) where
+  prettyM (Anno e t) = parens `above` annoPrec $
+    prettyM e <+> ":" <+> prettyM t

--- a/src/Syntax/Sized/Extracted.hs
+++ b/src/Syntax/Sized/Extracted.hs
@@ -8,6 +8,7 @@ import Data.Text(Text)
 import Data.Vector(Vector)
 
 import Syntax hiding (Definition, Module)
+import Syntax.Sized.Anno
 import TypeRep(TypeRep)
 import Util
 
@@ -15,12 +16,11 @@ data Expr v
   = Var v
   | Global QName
   | Lit Literal
-  | Con QConstr (Vector (Expr v)) -- ^ Fully applied
-  | Call (Expr v) (Vector (Expr v)) -- ^ Fully applied, only global
-  | PrimCall (Maybe Language) RetDir (Expr v) (Vector (Direction, Expr v))
-  | Let NameHint (Expr v) (Scope1 Expr v)
-  | Case (Expr v) (Branches () Expr v)
-  | Anno (Expr v) (Type v)
+  | Con QConstr (Vector (Anno Expr v)) -- ^ Fully applied
+  | Call (Expr v) (Vector (Anno Expr v)) -- ^ Fully applied, only global
+  | PrimCall (Maybe Language) RetDir (Expr v) (Vector (Direction, Anno Expr v))
+  | Let NameHint (Anno Expr v) (Scope1 Expr v)
+  | Case (Anno Expr v) (Branches () Expr v)
   deriving (Foldable, Functor, Traversable)
 
 type Type = Expr
@@ -42,20 +42,8 @@ emptySubmodule = Submodule mempty mempty
 
 -------------------------------------------------------------------------------
 -- Helpers
-pattern Sized :: Type v -> Expr v -> Expr v
-pattern Sized sz e = Anno e sz
-
 pattern MkType :: TypeRep -> Expr v
-pattern MkType rep <- (ignoreAnno -> Lit (TypeRep rep))
-  where MkType rep = Lit (TypeRep rep)
-
-ignoreAnno :: Expr v -> Expr v
-ignoreAnno (Anno e _) = ignoreAnno e
-ignoreAnno e = e
-
-typeOf :: Expr v -> Expr v
-typeOf (Anno _ rep) = rep
-typeOf _ = error "Extracted.typeOf"
+pattern MkType rep = Lit (TypeRep rep)
 
 typeDir :: Expr v -> Direction
 typeDir (MkType rep) = Direct rep
@@ -76,12 +64,11 @@ instance GlobalBind Expr where
     Var v -> f v
     Global v -> g v
     Lit l -> Lit l
-    Con c es -> Con c (bind f g <$> es)
-    Call e es -> Call (bind f g e) (bind f g <$> es)
-    PrimCall lang retDir e es -> PrimCall lang retDir (bind f g e) (fmap (bind f g) <$> es)
-    Let h e s -> Let h (bind f g e) (bound f g s)
-    Case e brs -> Case (bind f g e) (bound f g brs)
-    Anno e t -> Anno (bind f g e) (bind f g t)
+    Con c es -> Con c (bound f g <$> es)
+    Call e es -> Call (bind f g e) (bound f g <$> es)
+    PrimCall lang retDir e es -> PrimCall lang retDir (bind f g e) (fmap (bound f g) <$> es)
+    Let h e s -> Let h (bound f g e) (bound f g s)
+    Case e brs -> Case (bound f g e) (bound f g brs)
 
 instance Applicative Expr where
   pure = Var
@@ -104,8 +91,6 @@ instance v ~ Doc => Pretty (Expr v) where
     Case e brs -> parens `above` casePrec $
       "case" <+> inviolable (prettyM e) <+>
       "of" <$$> indent 2 (prettyM brs)
-    Anno e t -> parens `above` annoPrec $
-      prettyM e <+> ":" <+> prettyM t
 
 instance Monoid innards => Monoid (Submodule innards) where
   mempty = Submodule mempty mempty mempty

--- a/src/Syntax/Sized/SLambda.hs
+++ b/src/Syntax/Sized/SLambda.hs
@@ -8,6 +8,7 @@ import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 
 import Syntax
+import Syntax.Sized.Anno
 import TypeRep(TypeRep)
 import Util
 
@@ -15,13 +16,12 @@ data Expr v
   = Var v
   | Global QName
   | Lit Literal
-  | Con QConstr (Vector (Expr v)) -- ^ Fully applied
-  | Lam !NameHint (Type v) (Scope1 Expr v)
-  | App (Expr v) (Expr v)
+  | Con QConstr (Vector (Anno Expr v)) -- ^ Fully applied
+  | Lam !NameHint (Type v) (AnnoScope1 Expr v)
+  | App (Expr v) (Anno Expr v)
   | Let (LetRec Expr v) (Scope LetVar Expr v)
-  | Case (Expr v) (Branches () Expr v)
-  | Anno (Expr v) (Type v)
-  | ExternCode (Extern (Expr v))
+  | Case (Anno Expr v) (Branches () Expr v)
+  | ExternCode (Extern (Anno Expr v)) (Type v)
   deriving (Foldable, Functor, Traversable)
 
 type Type = Expr
@@ -29,21 +29,15 @@ type Type = Expr
 -------------------------------------------------------------------------------
 -- Helpers
 pattern MkType :: TypeRep -> Expr v
-pattern MkType rep <- (ignoreAnno -> Lit (TypeRep rep))
-  where MkType rep = Lit (TypeRep rep)
+pattern MkType rep = Lit (TypeRep rep)
 
-ignoreAnno :: Expr v -> Expr v
-ignoreAnno (Anno e _) = e
-ignoreAnno e = e
-
-appsView :: Expr v -> (Expr v, Vector (Expr v))
+appsView :: Expr v -> (Expr v, Vector (Anno Expr v))
 appsView = go []
   where
     go args (App e1 e2) = go (e2:args) e1
     go args e = (e, Vector.fromList args)
 
-lamView :: Expr v -> Maybe (NameHint, (), Expr v, Scope () Expr v)
-lamView (Anno e _) = lamView e
+lamView :: Expr v -> Maybe (NameHint, (), Expr v, AnnoScope () Expr v)
 lamView (Lam h e s) = Just (h, (), e, s)
 lamView _ = Nothing
 
@@ -67,8 +61,8 @@ instance Monad Expr where
   return = Var
   expr >>= f = bind f Global expr
 
-pattern Lams :: Telescope () Expr v -> Scope TeleVar Expr v -> Expr v
-pattern Lams tele s <- (bindingsViewM lamView -> Just (tele, s))
+pattern Lams :: Telescope () Expr v -> AnnoScope TeleVar Expr v -> Expr v
+pattern Lams tele s <- (annoBindingsViewM lamView -> Just (tele, s))
 
 instance GlobalBind Expr where
   global = Global
@@ -76,13 +70,12 @@ instance GlobalBind Expr where
     Var v -> f v
     Global v -> g v
     Lit l -> Lit l
-    Con qc es -> Con qc (bind f g <$> es)
+    Con qc es -> Con qc (bound f g <$> es)
     Lam h e s -> Lam h (bind f g e) (bound f g s)
-    App e1 e2 -> App (bind f g e1) (bind f g e2)
+    App e1 e2 -> App (bind f g e1) (bound f g e2)
     Let ds s -> Let (bound f g ds) (bound f g s)
-    Case e brs -> Case (bind f g e) (bound f g brs)
-    Anno e t -> Anno (bind f g e) (bind f g t)
-    ExternCode c -> ExternCode (bind f g <$> c)
+    Case e brs -> Case (bound f g e) (bound f g brs)
+    ExternCode c retType -> ExternCode (bound f g <$> c) (bind f g retType)
 
 instance v ~ Doc => Pretty (Expr v) where
   prettyM expr = case expr of
@@ -97,11 +90,9 @@ instance v ~ Doc => Pretty (Expr v) where
     Case e brs -> parens `above` casePrec $
       "case" <+> inviolable (prettyM e) <+>
       "of" <$$> indent 2 (prettyM brs)
-    Anno e t -> parens `above` annoPrec $
-      prettyM e <+> ":" <+> prettyM t
-    (bindingsViewM lamView -> Just (tele, s)) -> parens `above` absPrec $
+    (annoBindingsViewM lamView -> Just (tele, s)) -> parens `above` absPrec $
       withTeleHints tele $ \ns ->
         "\\" <> prettyTeleVarTypes ns tele <> "." <+>
-        associate absPrec (prettyM $ instantiateTele (pure . fromName) ns s)
+        associate absPrec (prettyM $ instantiateAnnoTele (pure . fromName) ns s)
     Lam {} -> error "impossible prettyPrec lam"
-    ExternCode c -> prettyM c
+    ExternCode c retType -> parens `above` annoPrec $ prettyM c <+> ":" <+> prettyM retType


### PR DESCRIPTION
The code generator expects there to be type annotations at certain
points in the expression tree, e.g. that all function and constructor
arguments start with a type annotation, but this was previously not
enforced by types.

This changes that by using an explicit `Anno` type where that is
expected, which gets rid of some `error`s and uses of "unknownSize" in
the backend.

There are still cases where we build invalid ASTs (e.g. with
"unknownSize") and rely on details of the code generator for it to work
(e.g. for the builtin pap and apply functions), but this at least
improves the situation.

Along the way we make some cleanups to the lambda lifter.