### PR TITLE
Rewrite pap & apply using new Fresh class

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -43,6 +43,7 @@ executable sixten
                        Command.Test
                        Error
                        FreeVar
+                       Fresh
                        Frontend.Declassify
                        Frontend.Parse
                        Frontend.ScopeCheck

--- a/src/Backend/ExtractExtern.hs
+++ b/src/Backend/ExtractExtern.hs
@@ -13,6 +13,7 @@ import qualified Data.Vector as Vector
 import Data.Void
 
 import Backend.Target
+import Fresh
 import Syntax
 import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
@@ -62,7 +63,7 @@ data ExtractState = ExtractState
   }
 
 newtype Extract a = Extract { unExtract :: StateT ExtractState VIX a }
-  deriving (Functor, Applicative, Monad, MonadState ExtractState, MonadVIX, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadState ExtractState, MonadFresh, MonadVIX, MonadIO)
 
 runExtract :: [QName] -> Target -> Extract a -> VIX ([(QName, Sized.Function Extracted.Expr Void)], Extracted.Submodule a)
 runExtract names tgt (Extract m) = do

--- a/src/Backend/Lift.hs
+++ b/src/Backend/Lift.hs
@@ -12,6 +12,7 @@ import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 import Data.Void
 
+import Fresh
 import Syntax
 import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
@@ -28,7 +29,7 @@ data LiftState thing = LiftState
   }
 
 newtype Lift thing m a = Lift (StateT (LiftState thing) m a)
-  deriving (Functor, Applicative, Monad, MonadState (LiftState thing), MonadTrans, MonadVIX, MonadIO, MonadError e)
+  deriving (Functor, Applicative, Monad, MonadState (LiftState thing), MonadTrans, MonadFresh, MonadVIX, MonadIO, MonadError e)
 
 freshName :: Monad m => Lift thing m QName
 freshName = do

--- a/src/FreeVar.hs
+++ b/src/FreeVar.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE FlexibleContexts #-}
 module FreeVar where
 
-import Control.Monad.IO.Class
 import Data.Function
 import Data.Hashable
 
+import Fresh
 import Syntax.NameHint
-import VIX
 
 data FreeVar d = FreeVar
   { varId :: !Int
@@ -24,7 +23,7 @@ instance Hashable (FreeVar d) where
   hashWithSalt s = hashWithSalt s . varId
 
 freeVar
-  :: (MonadVIX m, MonadIO m)
+  :: MonadFresh m
   => NameHint
   -> d
   -> m (FreeVar d)

--- a/src/Fresh.hs
+++ b/src/Fresh.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Fresh where
+
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Trans.Identity
+import Control.Monad.Writer
+
+import qualified LLVM.IRBuilder as IRBuilder
+
+class Monad m => MonadFresh m where
+  fresh :: m Int
+
+  default fresh
+    :: (MonadTrans t, MonadFresh m1, m ~ t m1)
+    => m Int
+  fresh = lift fresh
+
+
+newtype Fresh a = Fresh (State Int a)
+  deriving (Functor, Applicative, Monad, MonadState Int)
+
+evalFresh :: Fresh a -> a
+evalFresh (Fresh m) = evalState m 0
+
+instance MonadFresh Fresh where
+  fresh = do
+    i <- get
+    put $! i + 1
+    return i
+
+-------------------------------------------------------------------------------
+-- mtl instances
+-------------------------------------------------------------------------------
+instance MonadFresh m => MonadFresh (ReaderT r m)
+instance (Monoid w, MonadFresh m) => MonadFresh (WriterT w m)
+instance MonadFresh m => MonadFresh (StateT s m)
+instance MonadFresh m => MonadFresh (IdentityT m)
+instance MonadFresh m => MonadFresh (IRBuilder.IRBuilderT m)
+instance MonadFresh m => MonadFresh (IRBuilder.ModuleBuilderT m)

--- a/src/Inference/Meta.hs
+++ b/src/Inference/Meta.hs
@@ -17,6 +17,7 @@ import Data.String
 import qualified Data.Text.Prettyprint.Doc as PP
 import Data.Vector(Vector)
 
+import Fresh
 import Syntax
 import qualified Syntax.Abstract as Abstract
 import qualified Syntax.Concrete.Scoped as Concrete

--- a/src/TypedFreeVar.hs
+++ b/src/TypedFreeVar.hs
@@ -12,6 +12,7 @@ import Data.Monoid
 import Data.String
 import Data.Vector(Vector)
 
+import Fresh
 import Pretty
 import Syntax.Name
 import Syntax.NameHint
@@ -40,7 +41,7 @@ instance Hashable (FreeVar d) where
   hashWithSalt s = hashWithSalt s . varId
 
 freeVar
-  :: (MonadVIX m, MonadIO m)
+  :: MonadFresh m
   => NameHint
   -> d (FreeVar d)
   -> m (FreeVar d)

--- a/src/VIX.hs
+++ b/src/VIX.hs
@@ -26,6 +26,7 @@ import System.IO
 
 import Backend.Target as Target
 import Error
+import Fresh
 import Syntax
 import Syntax.Abstract
 import qualified Syntax.Sized.Lifted as Lifted
@@ -48,7 +49,7 @@ data VIXState = VIXState
   , vixTarget :: Target
   }
 
-class Monad m => MonadVIX m where
+class MonadFresh m => MonadVIX m where
   liftVIX :: State VIXState a -> m a
 
   default liftVIX
@@ -99,11 +100,11 @@ runVIX vix target handle verbosity
   $ evalStateT (unVIX vix)
   $ emptyVIXState target handle verbosity
 
-fresh :: MonadVIX m => m Int
-fresh = liftVIX $ do
-  i <- gets vixFresh
-  modify $ \s -> s {vixFresh = i + 1}
-  return i
+instance MonadFresh VIX where
+  fresh = liftVIX $ do
+    i <- gets vixFresh
+    modify $ \s -> s {vixFresh = i + 1}
+    return i
 
 located :: MonadVIX m => SourceLoc -> m a -> m a
 located loc m = do


### PR DESCRIPTION
This way we don't have to explicitly build De Bruijny scopes in an
error-prone way. We can instead just generate some fresh variables and
abstract over them.