### PR TITLE
Cleanup scopecheck

### DIFF
--- a/rts/Builtin1.vix
+++ b/rts/Builtin1.vix
@@ -33,7 +33,7 @@ maxInt x y = (C|
 abstract
 printInt : Int -> Int
 printInt x = (C|
-  printf("%zd\n", $x);
+  printf("%" PRId64 "\n", $x);
   return 0;
 |)
 

--- a/sixten.cabal
+++ b/sixten.cabal
@@ -46,7 +46,7 @@ executable sixten
                        Fresh
                        Frontend.Declassify
                        Frontend.Parse
-                       Frontend.ScopeCheck
+                       Frontend.ResolveNames
                        Inference.Constraint
                        Inference.Constructor
                        Inference.Cycle

--- a/src/Frontend/ResolveNames.hs
+++ b/src/Frontend/ResolveNames.hs
@@ -124,7 +124,6 @@ instances defs = fmap (MultiHashMap.fromList . concat) $ forM defs $ \(name, (_,
     return [(c, name)]
   _ -> return mempty
 
--- TODO add test for imports of empty modules
 importedAliases
   :: Import
   -> VIX (MultiHashMap QName QConstr, MultiHashMap QName QName)

--- a/src/Inference/TypeCheck/Expr.hs
+++ b/src/Inference/TypeCheck/Expr.hs
@@ -3,6 +3,7 @@ module Inference.TypeCheck.Expr where
 
 import Control.Monad.Except
 import Control.Monad.ST
+import Data.HashSet(HashSet)
 import Data.Monoid
 import Data.STRef
 import qualified Data.Vector as Vector
@@ -211,7 +212,7 @@ tcRho expr expected expectedAppResult = case expr of
 
 tcBranches
   :: ConcreteM
-  -> [(Concrete.Pat (PatternScope Concrete.Expr MetaA) (), PatternScope Concrete.Expr MetaA)]
+  -> [(Concrete.Pat (HashSet QConstr) (PatternScope Concrete.Expr MetaA) (), PatternScope Concrete.Expr MetaA)]
   -> Expected Rhotype
   -> Maybe Rhotype
   -> Infer AbstractM

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -211,6 +211,7 @@ instance Pretty Float  where pretty = fromString . show
 instance Pretty Double where pretty = fromString . show
 instance a ~ AnsiStyle => Pretty (PP.Doc a) where pretty = id
 instance Pretty Text where pretty = fromString . Text.unpack
+instance Pretty PreName where pretty (PreName n) = pretty n
 instance Pretty Name where pretty (Name n) = pretty n
 instance Pretty Constr where pretty (Constr c) = pretty c
 instance Pretty Void where pretty = absurd
@@ -244,6 +245,10 @@ instance (Pretty a, Pretty b, Pretty c) => Pretty (a, b, c) where
     <*> prettyM c
     where
       f x y z = PP.tupled [x, y, z]
+
+instance Pretty a => Pretty (HashSet a) where
+  prettyM s
+    = PP.encloseSep PP.lbrace PP.rbrace PP.comma <$> mapM (inviolable . prettyM) (HashSet.toList s)
 
 instance Pretty (Proxy a) where
   prettyM Proxy = "Proxy"

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -308,6 +308,7 @@ writeModule modul llOutputFile externOutputFiles = do
         [] -> return Nothing
         externCode -> Util.withFile outFile WriteMode $ \handle -> do
           -- TODO this is C specific
+          Text.hPutStrLn handle "#include <inttypes.h>"
           Text.hPutStrLn handle "#include <stdint.h>"
           Text.hPutStrLn handle "#include <stdio.h>"
           Text.hPutStrLn handle "#include <stdlib.h>"

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -29,7 +29,7 @@ import qualified Backend.SLam as SLam
 import Backend.Target
 import qualified Frontend.Declassify as Declassify
 import qualified Frontend.Parse as Parse
-import qualified Frontend.ScopeCheck as ScopeCheck
+import qualified Frontend.ResolveNames as ResolveNames
 import qualified Inference.Monad as TypeCheck
 import qualified Inference.TypeCheck.Definition as TypeCheck
 import Processor.Result
@@ -55,7 +55,7 @@ frontend
   -> Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [k]
 frontend k
-  = scopeCheckProgram
+  = resolveProgramNames
   >>=> prettyConcreteGroup "Concrete syntax" absurd
 
   >=> declassifyGroup
@@ -176,11 +176,11 @@ prettyGroup str f defs = do
       VIX.log ""
   return defs
 
-scopeCheckProgram
+resolveProgramNames
   :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
   -> VIX [[(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Type Void))]]
-scopeCheckProgram modul = do
-  res <- ScopeCheck.scopeCheckModule modul
+resolveProgramNames modul = do
+  res <- ResolveNames.resolveModule modul
   let defnames = HashSet.fromMap $ void $ moduleContents modul
       connames = HashSet.fromList
         [ QConstr n c

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -192,10 +192,7 @@ scopeCheckProgram modul = do
         | (QName n _, (_, Unscoped.TopLevelClassDefinition _ _ ms)) <- HashMap.toList $ moduleContents modul
         , m <- methodName <$> ms
         ]
-  addModule (moduleName modul)
-    $ HashSet.map Right defnames
-    <> HashSet.map Left connames
-    <> HashSet.map Right methods
+  addModule (moduleName modul) connames $ defnames <> methods
   return res
 
 declassifyGroup

--- a/src/Processor/Files.hs
+++ b/src/Processor/Files.hs
@@ -110,7 +110,7 @@ compileBuiltins = do
             | (n, (DataDefinition d _, _)) <- HashMap.toList context
             , c <- constrNames d
             ]
-      addModule "Sixten.Builtin" $ HashSet.map Right builtinDefNames <> HashSet.map Left builtinConstrNames
+      addModule "Sixten.Builtin" builtinConstrNames builtinDefNames
       addContext context
       builtinResults1 <- File.process builtins1
       let contextList = (\(n, (d, t)) -> (n, d, t)) <$> HashMap.toList context

--- a/src/Syntax/Concrete/Unscoped.hs
+++ b/src/Syntax/Concrete/Unscoped.hs
@@ -12,13 +12,13 @@ import Syntax.Concrete.Pattern
 type Con = Either Constr QConstr
 
 data Expr
-  = Var QName
+  = Var PreName
   | Lit Literal
-  | Pi !Plicitness (Pat Type QName) Expr
-  | Lam !Plicitness (Pat Type QName) Expr
+  | Pi !Plicitness (Pat PreName Type PreName) Expr
+  | Lam !Plicitness (Pat PreName Type PreName) Expr
   | App Expr !Plicitness Expr
   | Let (Vector (SourceLoc, Definition Expr)) Expr
-  | Case Expr [(Pat Expr QName, Expr)]
+  | Case Expr [(Pat PreName Expr PreName, Expr)]
   | ExternCode (Extern Expr)
   | Wildcard
   | SourceLoc !SourceLoc Type
@@ -40,19 +40,19 @@ data TopLevelDefinition
   | TopLevelInstanceDefinition Type [(SourceLoc, Definition Expr)]
   deriving (Show)
 
-data Clause e = Clause (Vector (Plicitness, Pat e QName)) e
+data Clause e = Clause (Vector (Plicitness, Pat PreName e PreName)) e
   deriving (Show)
 
 -------------------------------------------------------------------------------
 -- Smart constructors
 pis
-  :: [(Plicitness, Pat Type QName)]
+  :: [(Plicitness, Pat PreName Type PreName)]
   -> Expr
   -> Expr
 pis ps e = foldr (uncurry Pi) e ps
 
 lams
-  :: [(Plicitness, Pat Type QName)]
+  :: [(Plicitness, Pat PreName Type PreName)]
   -> Expr
   -> Expr
 lams ps e = foldr (uncurry Lam)  e ps

--- a/src/Syntax/Name.hs
+++ b/src/Syntax/Name.hs
@@ -7,6 +7,13 @@ import Data.Hashable
 
 import Util
 
+-- | An unresolved name
+newtype PreName = PreName Text
+  deriving (Eq, Hashable, Ord, Show, IsString, Monoid)
+
+fromPreName :: IsString a => PreName -> a
+fromPreName (PreName t) = fromText t
+
 newtype Name = Name Text
   deriving (Eq, Hashable, Ord, Show, IsString, Monoid)
 
@@ -18,9 +25,3 @@ newtype Constr = Constr Text
 
 fromConstr :: IsString a => Constr -> a
 fromConstr (Constr t) = fromText t
-
-constrToName :: Constr -> Name
-constrToName (Constr c) = Name c
-
-nameToConstr :: Name -> Constr
-nameToConstr (Name n) = Constr n

--- a/src/Util/MultiHashMap.hs
+++ b/src/Util/MultiHashMap.hs
@@ -137,3 +137,10 @@ mapKeys
   -> MultiHashMap k v
   -> MultiHashMap k' v
 mapKeys f = fromMultiList . Prelude.map (first f) . toMultiList
+
+mapWithKey
+  :: (Eq v', Hashable v')
+  => (k -> v -> v')
+  -> MultiHashMap k v
+  -> MultiHashMap k v'
+mapWithKey f (MultiHashMap m) = MultiHashMap $ HashMap.mapWithKey (HashSet.map . f) m

--- a/src/VIX.hs
+++ b/src/VIX.hs
@@ -76,7 +76,7 @@ emptyVIXState target handle verbosity = VIXState
   , vixTarget = target
   }
 
-newtype VIX a = VIX (StateT VIXState (ExceptT Error IO) a)
+newtype VIX a = VIX { unVIX :: StateT VIXState (ExceptT Error IO) a }
   deriving (Functor, Applicative, Monad, MonadFix, MonadError Error, MonadIO, MonadBase IO, MonadBaseControl IO)
 
 instance MonadVIX VIX where
@@ -84,11 +84,6 @@ instance MonadVIX VIX where
 
 liftST :: MonadIO m => ST RealWorld a -> m a
 liftST = liftIO . stToIO
-
-unVIX
-  :: VIX a
-  -> StateT VIXState (ExceptT Error IO) a
-unVIX (VIX x) = x
 
 -- TODO vixFresh should probably be a mutable variable
 runVIX

--- a/src/VIX.hs
+++ b/src/VIX.hs
@@ -37,7 +37,8 @@ import qualified Util.MultiHashMap as MultiHashMap
 data VIXState = VIXState
   { vixLocation :: Maybe SourceLoc
   , vixContext :: HashMap QName (Definition Expr Void, Type Void)
-  , vixModuleNames :: MultiHashMap ModuleName (Either QConstr QName)
+  , vixModuleConstrs :: MultiHashMap ModuleName QConstr
+  , vixModuleNames :: MultiHashMap ModuleName QName
   , vixConvertedSignatures :: HashMap QName Lifted.FunSignature
   , vixSignatures :: HashMap QName (Signature ReturnIndirect)
   , vixClassMethods :: HashMap QName (Vector Name)
@@ -62,6 +63,7 @@ emptyVIXState :: Target -> Handle -> Int -> VIXState
 emptyVIXState target handle verbosity = VIXState
   { vixLocation = Nothing
   , vixContext = mempty
+  , vixModuleConstrs = mempty
   , vixModuleNames = mempty
   , vixConvertedSignatures = mempty
   , vixSignatures = mempty
@@ -192,10 +194,12 @@ definition name = do
 addModule
   :: MonadVIX m
   => ModuleName
-  -> HashSet (Either QConstr QName)
+  -> HashSet QConstr
+  -> HashSet QName
   -> m ()
-addModule m names = liftVIX $ modify $ \s -> s
-  { vixModuleNames = MultiHashMap.inserts m names $ vixModuleNames s
+addModule m constrs names = liftVIX $ modify $ \s -> s
+  { vixModuleConstrs = MultiHashMap.inserts m constrs $ vixModuleConstrs s
+  , vixModuleNames = MultiHashMap.inserts m names $ vixModuleNames s
   }
 
 qconstructor :: (MonadVIX m, MonadError Error m) => QConstr -> m (Type v)

--- a/tests/success-multi/modules/Empty/Empty.vix
+++ b/tests/success-multi/modules/Empty/Empty.vix
@@ -1,0 +1,1 @@
+module Empty exposing ()

--- a/tests/success-multi/modules/Empty/Main.vix
+++ b/tests/success-multi/modules/Empty/Main.vix
@@ -1,0 +1,1 @@
+import Empty exposing (..)


### PR DESCRIPTION
* Separate ScopeChecking code into some different functions
* Rename ScopeCheck to ResolveNames
* Use separate PreName type for pre-name resolving names
* ... and more