### PR TITLE
Rename syntaxes

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -70,8 +70,8 @@ executable sixten
                        Processor.Files
                        Processor.Result
                        Syntax
-                       Syntax.Abstract
-                       Syntax.Abstract.Pattern
+                       Syntax.Core
+                       Syntax.Core.Pattern
                        Syntax.Annotation
                        Syntax.Branches
                        Syntax.Class

--- a/sixten.cabal
+++ b/sixten.cabal
@@ -75,11 +75,11 @@ executable sixten
                        Syntax.Annotation
                        Syntax.Branches
                        Syntax.Class
-                       Syntax.Concrete.Definition
-                       Syntax.Concrete.Literal
-                       Syntax.Concrete.Pattern
-                       Syntax.Concrete.Scoped
-                       Syntax.Concrete.Unscoped
+                       Syntax.Pre.Definition
+                       Syntax.Pre.Literal
+                       Syntax.Pre.Pattern
+                       Syntax.Pre.Scoped
+                       Syntax.Pre.Unscoped
                        Syntax.Data
                        Syntax.Definition
                        Syntax.Direction

--- a/src/Analysis/Simplify.hs
+++ b/src/Analysis/Simplify.hs
@@ -13,7 +13,7 @@ import qualified Data.Vector as Vector
 
 import Inference.Normalise
 import Syntax
-import Syntax.Abstract hiding (let_)
+import Syntax.Core hiding (let_)
 import Util
 
 simplifyExpr

--- a/src/Builtin.hs
+++ b/src/Builtin.hs
@@ -16,7 +16,7 @@ import Backend.Target(Target)
 import Builtin.Names
 import MonadFresh
 import Syntax
-import Syntax.Abstract as Abstract
+import Syntax.Core as Core
 import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
 import qualified Syntax.Sized.Lifted as Lifted
@@ -31,7 +31,7 @@ context target = HashMap.fromList
       (Lam mempty Explicit Type $ Scope ptrRep)
       (arrow Explicit Type Type)
       [ ConstrDef RefName $ toScope $ fmap B $ arrow Explicit (pure 0)
-        $ Abstract.App (Global PtrName) Explicit (pure 0)
+        $ Core.App (Global PtrName) Explicit (pure 0)
       ])
   , (IntName, opaqueData intRep Type)
   , (NatName, dataType intRep Type

--- a/src/Builtin/Names.hs
+++ b/src/Builtin/Names.hs
@@ -4,7 +4,7 @@ module Builtin.Names where
 import Data.Monoid
 import Data.String
 
-import Syntax.Abstract
+import Syntax.Core
 import Syntax.Annotation
 import Syntax.Module
 import Syntax.Name

--- a/src/Frontend/Declassify.hs
+++ b/src/Frontend/Declassify.hs
@@ -14,7 +14,7 @@ import Data.Void
 
 import Error
 import Syntax
-import Syntax.Concrete.Scoped
+import Syntax.Pre.Scoped
 import Util
 import VIX
 

--- a/src/Frontend/Parse.hs
+++ b/src/Frontend/Parse.hs
@@ -24,9 +24,9 @@ import Text.Parsix(Position(Position, visualRow, visualColumn), (<?>))
 import Error
 import Processor.Result
 import Syntax
-import Syntax.Concrete.Literal
-import Syntax.Concrete.Pattern
-import Syntax.Concrete.Unscoped as Unscoped
+import Syntax.Pre.Literal
+import Syntax.Pre.Pattern
+import Syntax.Pre.Unscoped as Unscoped
 
 data ParseEnv = ParseEnv
   { parseEnvIndentAnchor :: !Position

--- a/src/Frontend/ResolveNames.hs
+++ b/src/Frontend/ResolveNames.hs
@@ -15,10 +15,10 @@ import qualified Data.Vector as Vector
 import qualified Builtin.Names as Builtin
 import qualified Frontend.Declassify as Declassify
 import Syntax
-import qualified Syntax.Concrete.Literal as Literal
-import Syntax.Concrete.Pattern
-import qualified Syntax.Concrete.Scoped as Scoped
-import qualified Syntax.Concrete.Unscoped as Unscoped
+import qualified Syntax.Pre.Literal as Literal
+import Syntax.Pre.Pattern
+import qualified Syntax.Pre.Scoped as Scoped
+import qualified Syntax.Pre.Unscoped as Unscoped
 import Util
 import Util.MultiHashMap(MultiHashMap)
 import qualified Util.MultiHashMap as MultiHashMap

--- a/src/Inference/Constraint.hs-boot
+++ b/src/Inference/Constraint.hs-boot
@@ -2,4 +2,4 @@ module Inference.Constraint where
 
 import Inference.Monad
 
-whnf :: AbstractM -> Infer AbstractM
+whnf :: CoreM -> Infer CoreM

--- a/src/Inference/Constructor.hs
+++ b/src/Inference/Constructor.hs
@@ -10,7 +10,7 @@ import qualified Data.Text.Prettyprint.Doc as PP
 import Inference.Constraint
 import Inference.Monad
 import Syntax
-import qualified Syntax.Abstract as Abstract
+import qualified Syntax.Core as Core
 import TypedFreeVar
 import Util
 import VIX
@@ -49,15 +49,15 @@ resolveConstr cs expected = do
       ]
   where
     expectedDataType = join <$> traverse findExpectedDataType expected
-    findExpectedDataType :: AbstractM -> Infer (Maybe QName)
+    findExpectedDataType :: CoreM -> Infer (Maybe QName)
     findExpectedDataType typ = do
       typ' <- whnf typ
       case typ' of
-        Abstract.Pi h p t s -> do
+        Core.Pi h p t s -> do
           v <- freeVar h p t
           findExpectedDataType $ Util.instantiate1 (pure v) s
-        Abstract.App t1 _ _ -> findExpectedDataType t1
-        Abstract.Global v -> do
+        Core.App t1 _ _ -> findExpectedDataType t1
+        Core.Global v -> do
           (d, _) <- definition v
           return $ case d of
             DataDefinition _ _ -> Just v

--- a/src/Inference/Cycle.hs
+++ b/src/Inference/Cycle.hs
@@ -19,13 +19,13 @@ import Inference.MetaVar
 import Inference.MetaVar.Zonk
 import Inference.Monad
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 import TypedFreeVar
 import Util
 import Util.TopoSort
 
 detectTypeRepCycles
-  :: Vector (SourceLoc, (FreeV, Definition (Expr MetaVar) FreeV, AbstractM))
+  :: Vector (SourceLoc, (FreeV, Definition (Expr MetaVar) FreeV, CoreM))
   -> Infer ()
 detectTypeRepCycles defs = do
   reps <- traverse
@@ -85,7 +85,7 @@ detectTypeRepCycles defs = do
 -- We also peel off any lets at the top-level of all definitions and include
 -- them in the analysis.
 detectDefCycles
-  :: Vector (SourceLoc, (FreeV, Definition (Expr MetaVar) FreeV, AbstractM))
+  :: Vector (SourceLoc, (FreeV, Definition (Expr MetaVar) FreeV, CoreM))
   -> Infer ()
 detectDefCycles defs = do
   (peeledDefExprs, locMap) <- peelLets [(loc, v, e) | (loc, (v, Definition _ _ e, _)) <- Vector.toList defs]
@@ -116,13 +116,13 @@ detectDefCycles defs = do
                   ]
 
 peelLets
-  :: [(SourceLoc, FreeV, AbstractM)]
-  -> Infer ([(FreeV, AbstractM)], HashMap FreeV SourceLoc)
+  :: [(SourceLoc, FreeV, CoreM)]
+  -> Infer ([(FreeV, CoreM)], HashMap FreeV SourceLoc)
 peelLets = fmap fold . mapM go
   where
     go
-     :: (SourceLoc, FreeV, AbstractM)
-     -> Infer ([(FreeV, AbstractM)], HashMap FreeV SourceLoc)
+     :: (SourceLoc, FreeV, CoreM)
+     -> Infer ([(FreeV, CoreM)], HashMap FreeV SourceLoc)
     go (loc, v, e) = do
       e' <- zonk e
       case e' of

--- a/src/Inference/MetaVar.hs
+++ b/src/Inference/MetaVar.hs
@@ -20,7 +20,7 @@ import Error
 import MonadContext
 import MonadFresh
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 import TypedFreeVar
 import Util
 import VIX

--- a/src/Inference/MetaVar/Zonk.hs
+++ b/src/Inference/MetaVar/Zonk.hs
@@ -11,7 +11,7 @@ import Data.Void
 import Analysis.Simplify
 import Inference.MetaVar
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 
 zonk :: MonadIO m => Expr MetaVar v -> m (Expr MetaVar v)
 zonk = hoistMetas $ \m es -> do

--- a/src/Inference/Monad.hs
+++ b/src/Inference/Monad.hs
@@ -10,7 +10,7 @@ import Inference.MetaVar
 import MonadContext
 import MonadFresh
 import Syntax
-import qualified Syntax.Abstract as Abstract
+import qualified Syntax.Core as Core
 import qualified Syntax.Concrete.Scoped as Concrete
 import TypedFreeVar
 import Util
@@ -18,10 +18,10 @@ import Util.Tsil(Tsil)
 import VIX
 
 type ConcreteM = Concrete.Expr FreeV
-type AbstractM = Abstract.Expr MetaVar FreeV
+type CoreM = Core.Expr MetaVar FreeV
 
-type Polytype = AbstractM
-type Rhotype = AbstractM -- No top-level foralls
+type Polytype = CoreM
+type Rhotype = CoreM -- No top-level foralls
 
 newtype InstUntil = InstUntil Plicitness
   deriving (Eq, Ord, Show)
@@ -70,22 +70,22 @@ enterLevel (InferMonad m) = InferMonad $ local (\e -> e { inferLevel = inferLeve
 exists
   :: NameHint
   -> Plicitness
-  -> AbstractM
-  -> Infer AbstractM
+  -> CoreM
+  -> Infer CoreM
 exists hint d typ = do
   locals <- toVector <$> localVars
   let tele = varTelescope locals
       abstr = teleAbstraction locals
-      typ' = Abstract.pis tele $ abstract abstr typ
+      typ' = Core.pis tele $ abstract abstr typ
   logMeta 30 "exists typ" typ
   typ'' <- traverse (error "exists not closed") typ'
   loc <- currentLocation
   v <- existsAtLevel hint d typ'' (teleLength tele) loc =<< level
-  return $ Abstract.Meta v $ (\fv -> (varData fv, pure fv)) <$> locals
+  return $ Core.Meta v $ (\fv -> (varData fv, pure fv)) <$> locals
 
 existsType
   :: NameHint
-  -> Infer AbstractM
+  -> Infer CoreM
 existsType n = exists n Explicit Builtin.Type
 
 getTouchable :: Infer (MetaVar -> Bool)

--- a/src/Inference/Monad.hs
+++ b/src/Inference/Monad.hs
@@ -11,13 +11,13 @@ import MonadContext
 import MonadFresh
 import Syntax
 import qualified Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
+import qualified Syntax.Pre.Scoped as Pre
 import TypedFreeVar
 import Util
 import Util.Tsil(Tsil)
 import VIX
 
-type ConcreteM = Concrete.Expr FreeV
+type PreM = Pre.Expr FreeV
 type CoreM = Core.Expr MetaVar FreeV
 
 type Polytype = CoreM

--- a/src/Inference/Normalise.hs
+++ b/src/Inference/Normalise.hs
@@ -12,7 +12,7 @@ import Inference.MetaVar
 import Inference.Monad
 import MonadContext
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 import TypedFreeVar
 import TypeRep(TypeRep)
 import qualified TypeRep
@@ -25,8 +25,8 @@ type MonadNormalise m = (MonadIO m, MonadVIX m, MonadContext FreeV m, MonadError
 -- * Weak head normal forms
 whnf
   :: MonadNormalise m
-  => AbstractM
-  -> m AbstractM
+  => CoreM
+  -> m CoreM
 whnf = whnf' WhnfArgs
   { expandTypeReps = False
   , handleMetaVar = \m -> do
@@ -39,8 +39,8 @@ whnf = whnf' WhnfArgs
 
 whnfExpandingTypeReps
   :: MonadNormalise m
-  => AbstractM
-  -> m AbstractM
+  => CoreM
+  -> m CoreM
 whnfExpandingTypeReps = whnf' WhnfArgs
   { expandTypeReps = True
   , handleMetaVar = \m -> do
@@ -63,9 +63,9 @@ data WhnfArgs m = WhnfArgs
 whnf'
   :: MonadNormalise m
   => WhnfArgs m
-  -> [(Plicitness, AbstractM)] -- ^ Arguments to the expression
-  -> AbstractM -- ^ Expression to normalise
-  -> m AbstractM
+  -> [(Plicitness, CoreM)] -- ^ Arguments to the expression
+  -> CoreM -- ^ Expression to normalise
+  -> m CoreM
 whnf' args exprs expr = indentLog $ do
   logMeta 40 "whnf e" expr
   res <- go expr exprs
@@ -121,8 +121,8 @@ whnf' args exprs expr = indentLog $ do
 
 normalise
   :: MonadNormalise m
-  => AbstractM
-  -> m AbstractM
+  => CoreM
+  -> m CoreM
 normalise expr = do
   logMeta 40 "normalise e" expr
   res <- indentLog $ case expr of
@@ -260,7 +260,7 @@ instantiateLetM
   :: (MonadFix m, MonadIO m, MonadVIX m)
   => LetRec (Expr MetaVar) FreeV
   -> Scope LetVar (Expr MetaVar) FreeV
-  -> m AbstractM
+  -> m CoreM
 instantiateLetM ds scope = mdo
   vs <- forMLet ds $ \h s t -> letVar h Explicit (instantiateLet pure vs s) t
   return $ instantiateLet pure vs scope

--- a/src/Inference/Subtype.hs
+++ b/src/Inference/Subtype.hs
@@ -11,7 +11,7 @@ import Inference.Monad
 import Inference.Unify
 import MonadContext
 import Syntax
-import Syntax.Abstract as Abstract
+import Syntax.Core as Core
 import qualified Syntax.Concrete.Scoped as Concrete
 import TypedFreeVar
 import Util
@@ -28,7 +28,7 @@ import VIX
 skolemise
   :: Polytype
   -> InstUntil
-  -> (Rhotype -> (AbstractM -> AbstractM) -> Infer a)
+  -> (Rhotype -> (CoreM -> CoreM) -> Infer a)
   -> Infer a
 skolemise typ instUntil k = do
   typ' <- whnf typ
@@ -37,7 +37,7 @@ skolemise typ instUntil k = do
 skolemise'
   :: Polytype
   -> InstUntil
-  -> (Rhotype -> (AbstractM -> AbstractM) -> Infer a)
+  -> (Rhotype -> (CoreM -> CoreM) -> Infer a)
   -> Infer a
 skolemise' (Pi h p t resScope) instUntil k
   | shouldInst p instUntil = do
@@ -55,7 +55,7 @@ instUntilExpr _ = InstUntil Explicit
 --------------------------------------------------------------------------------
 -- Subtyping/subsumption
 -- | subtype t1 t2 = f => f : t1 -> t2
-subtype :: Polytype -> Polytype -> Infer (AbstractM -> AbstractM)
+subtype :: Polytype -> Polytype -> Infer (CoreM -> CoreM)
 subtype typ1 typ2 = do
   logMeta 30 "subtype t1" typ1
   logMeta 30 "        t2" typ2
@@ -64,7 +64,7 @@ subtype typ1 typ2 = do
     typ2' <- whnf typ2
     subtype' typ1' typ2'
 
-subtype' :: Polytype -> Polytype -> Infer (AbstractM -> AbstractM)
+subtype' :: Polytype -> Polytype -> Infer (CoreM -> CoreM)
 subtype' (Pi h1 p1 argType1 retScope1) (Pi h2 p2 argType2 retScope2)
   | p1 == p2 = do
     let h = h1 <> h2
@@ -83,7 +83,7 @@ subtype' typ1 typ2 =
     f2 <- subtypeRho typ1 rho $ InstUntil Explicit
     return $ f1 . f2
 
-subtypeRho :: Polytype -> Rhotype -> InstUntil -> Infer (AbstractM -> AbstractM)
+subtypeRho :: Polytype -> Rhotype -> InstUntil -> Infer (CoreM -> CoreM)
 subtypeRho typ1 typ2 instUntil = do
   logMeta 30 "subtypeRho t1" typ1
   logMeta 30 "           t2" typ2
@@ -92,7 +92,7 @@ subtypeRho typ1 typ2 instUntil = do
     typ2' <- whnf typ2
     subtypeRho' typ1' typ2' instUntil
 
-subtypeRho' :: Polytype -> Rhotype -> InstUntil -> Infer (AbstractM -> AbstractM)
+subtypeRho' :: Polytype -> Rhotype -> InstUntil -> Infer (CoreM -> CoreM)
 subtypeRho' typ1 typ2 _ | typ1 == typ2 = return id
 subtypeRho' (Pi h1 p1 argType1 retScope1) (Pi h2 p2 argType2 retScope2) _
   | p1 == p2 = do
@@ -122,7 +122,7 @@ funSubtypes
   -> Infer
     ( Telescope Plicitness (Expr MetaVar) FreeV
     , Scope TeleVar (Expr MetaVar) FreeV
-    , Vector (AbstractM -> AbstractM)
+    , Vector (CoreM -> CoreM)
     )
 funSubtypes startType plics = go plics startType mempty mempty mempty
   where
@@ -153,7 +153,7 @@ funSubtypes startType plics = go plics startType mempty mempty mempty
 funSubtype
   :: Rhotype
   -> Plicitness
-  -> Infer (NameHint, Rhotype, Scope1 (Expr MetaVar) FreeV, AbstractM -> AbstractM)
+  -> Infer (NameHint, Rhotype, Scope1 (Expr MetaVar) FreeV, CoreM -> CoreM)
 funSubtype typ p = do
   typ' <- whnf typ
   funSubtype' typ' p
@@ -161,7 +161,7 @@ funSubtype typ p = do
 funSubtype'
   :: Rhotype
   -> Plicitness
-  -> Infer (NameHint, Rhotype, Scope1 (Expr MetaVar) FreeV, AbstractM -> AbstractM)
+  -> Infer (NameHint, Rhotype, Scope1 (Expr MetaVar) FreeV, CoreM -> CoreM)
 funSubtype' (Pi h p t s) p' | p == p' = return (h, t, s, id)
 funSubtype' typ p = do
   argType <- existsType mempty
@@ -174,7 +174,7 @@ funSubtype' typ p = do
 subtypeFun
   :: Rhotype
   -> Plicitness
-  -> Infer (Rhotype, Scope1 (Expr MetaVar) FreeV, AbstractM -> AbstractM)
+  -> Infer (Rhotype, Scope1 (Expr MetaVar) FreeV, CoreM -> CoreM)
 subtypeFun typ p = do
   typ' <- whnf typ
   subtypeFun' typ' p
@@ -182,7 +182,7 @@ subtypeFun typ p = do
 subtypeFun'
   :: Rhotype
   -> Plicitness
-  -> Infer (Rhotype, Scope1 (Expr MetaVar) FreeV, AbstractM -> AbstractM)
+  -> Infer (Rhotype, Scope1 (Expr MetaVar) FreeV, CoreM -> CoreM)
 subtypeFun' (Pi _ p t s) p' | p == p' = return (t, s, id)
 subtypeFun' typ p = do
   argType <- existsType mempty

--- a/src/Inference/Subtype.hs
+++ b/src/Inference/Subtype.hs
@@ -12,7 +12,7 @@ import Inference.Unify
 import MonadContext
 import Syntax
 import Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
+import qualified Syntax.Pre.Scoped as Pre
 import TypedFreeVar
 import Util
 import Util.Tsil
@@ -48,8 +48,8 @@ skolemise' (Pi h p t resScope) instUntil k
       k resType' f'
 skolemise' typ _ k = k typ id
 
-instUntilExpr :: Concrete.Expr v -> InstUntil
-instUntilExpr (Concrete.Lam p _ _) = InstUntil p
+instUntilExpr :: Pre.Expr v -> InstUntil
+instUntilExpr (Pre.Lam p _ _) = InstUntil p
 instUntilExpr _ = InstUntil Explicit
 
 --------------------------------------------------------------------------------

--- a/src/Inference/TypeCheck/Clause.hs
+++ b/src/Inference/TypeCheck/Clause.hs
@@ -20,7 +20,7 @@ import Inference.Subtype
 import Inference.TypeCheck.Pattern
 import MonadContext
 import Syntax
-import qualified Syntax.Abstract as Abstract
+import qualified Syntax.Core as Core
 import qualified Syntax.Concrete.Scoped as Concrete
 import TypedFreeVar
 import Util
@@ -29,7 +29,7 @@ import VIX
 checkClauses
   :: NonEmpty (Concrete.Clause Void Concrete.Expr FreeV)
   -> Polytype
-  -> Infer AbstractM
+  -> Infer CoreM
 checkClauses clauses polyType = indentLog $ do
   forM_ clauses $ \clause -> logPretty 20 "checkClauses clause" $ pretty <$> clause
   logMeta 20 "checkClauses typ" polyType
@@ -57,13 +57,13 @@ checkClauses clauses polyType = indentLog $ do
       | Vector.length pats > 0 = InstUntil $ fst $ Vector.head pats
       | otherwise = instUntilExpr $ fromScope s
 
-    piPlicitnesses :: AbstractM -> Infer [Plicitness]
+    piPlicitnesses :: CoreM -> Infer [Plicitness]
     piPlicitnesses t = do
       t' <- whnf t
       piPlicitnesses' t'
 
-    piPlicitnesses' :: AbstractM -> Infer [Plicitness]
-    piPlicitnesses' (Abstract.Pi h p t s) = do
+    piPlicitnesses' :: CoreM -> Infer [Plicitness]
+    piPlicitnesses' (Core.Pi h p t s) = do
       v <- forall h p t
       (:) p <$> piPlicitnesses (instantiate1 (pure v) s)
     piPlicitnesses' _ = return mempty
@@ -71,7 +71,7 @@ checkClauses clauses polyType = indentLog $ do
 checkClausesRho
   :: NonEmpty (Concrete.Clause Void Concrete.Expr FreeV)
   -> Rhotype
-  -> Infer AbstractM
+  -> Infer CoreM
 checkClausesRho clauses rhoType = do
   forM_ clauses $ \clause -> logPretty 20 "checkClausesRho clause" $ pretty <$> clause
   logMeta 20 "checkClausesRho type" rhoType
@@ -110,7 +110,7 @@ checkClausesRho clauses rhoType = do
 
     let result = foldr
           (\(f, v) e ->
-            f $ Abstract.Lam (varHint v) (varData v) (varType v) $ abstract1 v e)
+            f $ Core.Lam (varHint v) (varData v) (varType v) $ abstract1 v e)
           body
           (Vector.zip fs argVars)
 

--- a/src/Inference/TypeCheck/Clause.hs
+++ b/src/Inference/TypeCheck/Clause.hs
@@ -21,13 +21,13 @@ import Inference.TypeCheck.Pattern
 import MonadContext
 import Syntax
 import qualified Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
+import qualified Syntax.Pre.Scoped as Pre
 import TypedFreeVar
 import Util
 import VIX
 
 checkClauses
-  :: NonEmpty (Concrete.Clause Void Concrete.Expr FreeV)
+  :: NonEmpty (Pre.Clause Void Pre.Expr FreeV)
   -> Polytype
   -> Infer CoreM
 checkClauses clauses polyType = indentLog $ do
@@ -37,9 +37,9 @@ checkClauses clauses polyType = indentLog $ do
   skolemise polyType (minimum $ instUntilClause <$> clauses) $ \rhoType f -> do
     ps <- piPlicitnesses rhoType
 
-    clauses' <- forM clauses $ \(Concrete.Clause pats body) -> do
+    clauses' <- forM clauses $ \(Pre.Clause pats body) -> do
       pats' <- equalisePats ps $ Vector.toList pats
-      return $ Concrete.Clause (Vector.fromList pats') body
+      return $ Pre.Clause (Vector.fromList pats') body
 
     let equalisedClauses = equaliseClauses clauses'
 
@@ -52,8 +52,8 @@ checkClauses clauses polyType = indentLog $ do
 
     return $ f res
   where
-    instUntilClause :: Concrete.Clause Void Concrete.Expr v -> InstUntil
-    instUntilClause (Concrete.Clause pats s)
+    instUntilClause :: Pre.Clause Void Pre.Expr v -> InstUntil
+    instUntilClause (Pre.Clause pats s)
       | Vector.length pats > 0 = InstUntil $ fst $ Vector.head pats
       | otherwise = instUntilExpr $ fromScope s
 
@@ -69,7 +69,7 @@ checkClauses clauses polyType = indentLog $ do
     piPlicitnesses' _ = return mempty
 
 checkClausesRho
-  :: NonEmpty (Concrete.Clause Void Concrete.Expr FreeV)
+  :: NonEmpty (Pre.Clause Void Pre.Expr FreeV)
   -> Rhotype
   -> Infer CoreM
 checkClausesRho clauses rhoType = do
@@ -78,12 +78,12 @@ checkClausesRho clauses rhoType = do
 
   let (ps, firstPats) = Vector.unzip ppats
         where
-          Concrete.Clause ppats _ = NonEmpty.head clauses
+          Pre.Clause ppats _ = NonEmpty.head clauses
   (argTele, returnTypeScope, fs) <- funSubtypes rhoType ps
 
   clauses' <- indentLog $ forM clauses $ \clause -> do
-    let pats = Concrete.clausePatterns' clause
-        bodyScope = Concrete.clauseScope' clause
+    let pats = Pre.clausePatterns' clause
+        bodyScope = Pre.clauseScope' clause
     (pats', patVars) <- tcPats pats mempty argTele
     let body = instantiatePattern pure (boundPatVars patVars) bodyScope
         argExprs = snd3 <$> pats'
@@ -95,7 +95,7 @@ checkClausesRho clauses rhoType = do
     forM_ pats $ logPretty 20 "checkClausesRho clause pat" <=< bitraverse prettyMeta (pure . pretty)
     logMeta 20 "checkClausesRho clause body" body
 
-  argVars <- forTeleWithPrefixM (addTeleNames argTele $ Concrete.patternHint <$> firstPats) $ \h p s argVars ->
+  argVars <- forTeleWithPrefixM (addTeleNames argTele $ Pre.patternHint <$> firstPats) $ \h p s argVars ->
     forall h p $ instantiateTele pure argVars s
 
   withVars argVars $ do
@@ -121,17 +121,17 @@ checkClausesRho clauses rhoType = do
 -- "Equalisation" -- making the clauses' number of patterns match eachother
 -- by adding implicits and eta-converting
 equaliseClauses
-  :: NonEmpty (Concrete.Clause b Concrete.Expr v)
-  -> NonEmpty (Concrete.Clause b Concrete.Expr v)
+  :: NonEmpty (Pre.Clause b Pre.Expr v)
+  -> NonEmpty (Pre.Clause b Pre.Expr v)
 equaliseClauses clauses
   = NonEmpty.zipWith
     (uncurry etaClause)
-    (go (Vector.toList . Concrete.clausePatterns <$> clauses))
-    (Concrete.clauseScope <$> clauses)
+    (go (Vector.toList . Pre.clausePatterns <$> clauses))
+    (Pre.clauseScope <$> clauses)
   where
     go
-      :: NonEmpty [(Plicitness, Concrete.Pat c (Scope b expr v) ())]
-      -> NonEmpty ([(Plicitness, Concrete.Pat c (Scope b expr v) ())], [Plicitness])
+      :: NonEmpty [(Plicitness, Pre.Pat c (Scope b expr v) ())]
+      -> NonEmpty ([(Plicitness, Pre.Pat c (Scope b expr v) ())], [Plicitness])
     go clausePats
       | numEx == 0 && numIm == 0 = (\pats -> (pats, mempty)) <$> clausePats
       | numEx == len = NonEmpty.zipWith (first . (:)) heads $ go tails
@@ -146,15 +146,15 @@ equaliseClauses clauses
         tails = tail <$> clausePats
         len = length clausePats
     go'
-      :: NonEmpty ([(Plicitness, Concrete.Pat c (Scope b expr v) ())], [Plicitness])
-      -> NonEmpty ([(Plicitness, Concrete.Pat c (Scope b expr v) ())], [Plicitness])
+      :: NonEmpty ([(Plicitness, Pre.Pat c (Scope b expr v) ())], [Plicitness])
+      -> NonEmpty ([(Plicitness, Pre.Pat c (Scope b expr v) ())], [Plicitness])
     go' clausePats
       = NonEmpty.zipWith
         (\ps (pats, ps') -> (pats, ps ++ ps'))
         (snd <$> clausePats)
         (go $ fst <$> clausePats)
 
-    numExplicit, numImplicit :: NonEmpty [(Plicitness, Concrete.Pat c (Scope b expr v) ())] -> Int
+    numExplicit, numImplicit :: NonEmpty [(Plicitness, Pre.Pat c (Scope b expr v) ())] -> Int
     numExplicit = length . NonEmpty.filter (\xs -> case xs of
       (Explicit, _):_ -> True
       _ -> False)
@@ -164,24 +164,24 @@ equaliseClauses clauses
       _ -> False)
 
     addImplicit, addExplicit
-      :: [(Plicitness, Concrete.Pat c (Scope b expr v) ())]
-      -> ([(Plicitness, Concrete.Pat c (Scope b expr v) ())], [Plicitness])
+      :: [(Plicitness, Pre.Pat c (Scope b expr v) ())]
+      -> ([(Plicitness, Pre.Pat c (Scope b expr v) ())], [Plicitness])
     addImplicit pats@((Implicit, _):_) = (pats, mempty)
-    addImplicit pats = ((Implicit, Concrete.WildcardPat) : pats, mempty)
+    addImplicit pats = ((Implicit, Pre.WildcardPat) : pats, mempty)
 
     addExplicit pats@((Explicit, _):_) = (pats, mempty)
-    addExplicit pats = ((Explicit, Concrete.VarPat mempty ()) : pats, pure Explicit)
+    addExplicit pats = ((Explicit, Pre.VarPat mempty ()) : pats, pure Explicit)
 
 etaClause
-  :: [(Plicitness, Concrete.Pat (HashSet QConstr) (Scope (Var PatternVar b) Concrete.Expr v) ())]
+  :: [(Plicitness, Pre.Pat (HashSet QConstr) (Scope (Var PatternVar b) Pre.Expr v) ())]
   -> [Plicitness]
-  -> Scope (Var PatternVar b) Concrete.Expr v
-  -> Concrete.Clause b Concrete.Expr v
+  -> Scope (Var PatternVar b) Pre.Expr v
+  -> Pre.Clause b Pre.Expr v
 etaClause pats extras (Scope scope)
-  = Concrete.Clause
+  = Pre.Clause
     (Vector.fromList pats)
     $ Scope
-    $ Concrete.apps scope vs
+    $ Pre.apps scope vs
   where
     numBindings = length $ concat $ Foldable.toList . snd <$> pats
     numExtras = length extras

--- a/src/Inference/TypeCheck/Data.hs
+++ b/src/Inference/TypeCheck/Data.hs
@@ -14,13 +14,13 @@ import Inference.Unify
 import MonadContext
 import Syntax
 import qualified Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
+import qualified Syntax.Pre.Scoped as Pre
 import TypedFreeVar
 import qualified TypeRep
 import VIX
 
 checkConstrDef
-  :: ConstrDef ConcreteM
+  :: ConstrDef PreM
   -> Infer (ConstrDef CoreM, CoreM, CoreM)
 checkConstrDef (ConstrDef c typ) = do
   typ' <- zonk =<< checkPoly typ Builtin.Type
@@ -38,7 +38,7 @@ checkConstrDef (ConstrDef c typ) = do
 
 checkDataType
   :: FreeV
-  -> DataDef Concrete.Expr FreeV
+  -> DataDef Pre.Expr FreeV
   -> CoreM
   -> Infer (Definition (Core.Expr MetaVar) FreeV, CoreM)
 checkDataType name (DataDef cs) typ = do

--- a/src/Inference/TypeCheck/Definition.hs
+++ b/src/Inference/TypeCheck/Definition.hs
@@ -33,32 +33,32 @@ import Inference.Unify
 import MonadContext
 import Syntax
 import qualified Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
+import qualified Syntax.Pre.Scoped as Pre
 import TypedFreeVar
 import Util
 import Util.TopoSort
 import VIX
 
 checkDefType
-  :: Concrete.PatDefinition (Concrete.Clause Void Concrete.Expr FreeV)
+  :: Pre.PatDefinition (Pre.Clause Void Pre.Expr FreeV)
   -> CoreM
   -> Infer (Definition (Core.Expr MetaVar) FreeV, CoreM)
-checkDefType (Concrete.PatDefinition a i clauses) typ = do
+checkDefType (Pre.PatDefinition a i clauses) typ = do
   e' <- checkClauses clauses typ
   return (Definition a i e', typ)
 
 checkTopLevelDefType
   :: FreeV
-  -> Concrete.TopLevelPatDefinition Concrete.Expr FreeV
+  -> Pre.TopLevelPatDefinition Pre.Expr FreeV
   -> SourceLoc
   -> CoreM
   -> Infer (Definition (Core.Expr MetaVar) FreeV, CoreM)
 checkTopLevelDefType v def loc typ = located loc $ case def of
-  Concrete.TopLevelPatDefinition def' -> checkDefType def' typ
-  Concrete.TopLevelPatDataDefinition d -> checkDataType v d typ
+  Pre.TopLevelPatDefinition def' -> checkDefType def' typ
+  Pre.TopLevelPatDataDefinition d -> checkDataType v d typ
   -- Should be removed by Declassify:
-  Concrete.TopLevelPatClassDefinition _ -> error "checkTopLevelDefType class"
-  Concrete.TopLevelPatInstanceDefinition _ -> error "checkTopLevelDefType instance"
+  Pre.TopLevelPatClassDefinition _ -> error "checkTopLevelDefType class"
+  Pre.TopLevelPatInstanceDefinition _ -> error "checkTopLevelDefType instance"
 
 abstractDefImplicits
   :: Foldable t
@@ -317,8 +317,8 @@ checkRecursiveDefs
   -> Vector
     ( FreeV
     , ( SourceLoc
-      , Concrete.TopLevelPatDefinition Concrete.Expr FreeV
-      , Maybe ConcreteM
+      , Pre.TopLevelPatDefinition Pre.Expr FreeV
+      , Maybe PreM
       )
     )
   -> Infer
@@ -393,7 +393,7 @@ checkTopLevelDefs
   :: Vector
     ( FreeV
     , ( SourceLoc
-      , Concrete.TopLevelPatDefinition Concrete.Expr FreeV
+      , Pre.TopLevelPatDefinition Pre.Expr FreeV
       )
     )
   -> Infer
@@ -421,33 +421,33 @@ shouldGeneralise
   :: Vector
     ( FreeV
     , ( SourceLoc
-      , Concrete.TopLevelPatDefinition Concrete.Expr FreeV
-      , Maybe ConcreteM
+      , Pre.TopLevelPatDefinition Pre.Expr FreeV
+      , Maybe PreM
       )
     )
   -> Bool
 shouldGeneralise = all (\(_, (_, def, _)) -> shouldGeneraliseDef def)
   where
-    shouldGeneraliseDef (Concrete.TopLevelPatDefinition (Concrete.PatDefinition _ _ (Concrete.Clause ps _ NonEmpty.:| _))) = Vector.length ps > 0
-    shouldGeneraliseDef Concrete.TopLevelPatDataDefinition {} = True
-    shouldGeneraliseDef Concrete.TopLevelPatClassDefinition {} = True
-    shouldGeneraliseDef Concrete.TopLevelPatInstanceDefinition {} = True
+    shouldGeneraliseDef (Pre.TopLevelPatDefinition (Pre.PatDefinition _ _ (Pre.Clause ps _ NonEmpty.:| _))) = Vector.length ps > 0
+    shouldGeneraliseDef Pre.TopLevelPatDataDefinition {} = True
+    shouldGeneraliseDef Pre.TopLevelPatClassDefinition {} = True
+    shouldGeneraliseDef Pre.TopLevelPatInstanceDefinition {} = True
 
 defPlicitness
-  :: Concrete.TopLevelPatDefinition e v
+  :: Pre.TopLevelPatDefinition e v
   -> Plicitness
-defPlicitness (Concrete.TopLevelPatDefinition (Concrete.PatDefinition _ IsInstance _)) = Constraint
-defPlicitness Concrete.TopLevelPatDefinition {} = Explicit
-defPlicitness Concrete.TopLevelPatDataDefinition {} = Explicit
-defPlicitness Concrete.TopLevelPatClassDefinition {} = Explicit
-defPlicitness Concrete.TopLevelPatInstanceDefinition {} = Explicit
+defPlicitness (Pre.TopLevelPatDefinition (Pre.PatDefinition _ IsInstance _)) = Constraint
+defPlicitness Pre.TopLevelPatDefinition {} = Explicit
+defPlicitness Pre.TopLevelPatDataDefinition {} = Explicit
+defPlicitness Pre.TopLevelPatClassDefinition {} = Explicit
+defPlicitness Pre.TopLevelPatInstanceDefinition {} = Explicit
 
 checkTopLevelRecursiveDefs
   :: Vector
     ( QName
     , SourceLoc
-    , Concrete.TopLevelPatDefinition Concrete.Expr Void
-    , Maybe (Concrete.Type Void)
+    , Pre.TopLevelPatDefinition Pre.Expr Void
+    , Maybe (Pre.Type Void)
     )
   -> Infer
     (Vector

--- a/src/Inference/TypeCheck/Expr.hs-boot
+++ b/src/Inference/TypeCheck/Expr.hs-boot
@@ -2,5 +2,5 @@ module Inference.TypeCheck.Expr where
 
 import Inference.Monad
 
-checkPoly :: ConcreteM -> Polytype -> Infer AbstractM
-checkRho :: ConcreteM -> Rhotype -> Infer AbstractM
+checkPoly :: ConcreteM -> Polytype -> Infer CoreM
+checkRho :: ConcreteM -> Rhotype -> Infer CoreM

--- a/src/Inference/TypeCheck/Expr.hs-boot
+++ b/src/Inference/TypeCheck/Expr.hs-boot
@@ -2,5 +2,5 @@ module Inference.TypeCheck.Expr where
 
 import Inference.Monad
 
-checkPoly :: ConcreteM -> Polytype -> Infer CoreM
-checkRho :: ConcreteM -> Rhotype -> Infer CoreM
+checkPoly :: PreM -> Polytype -> Infer CoreM
+checkRho :: PreM -> Rhotype -> Infer CoreM

--- a/src/Inference/TypeOf.hs
+++ b/src/Inference/TypeOf.hs
@@ -12,7 +12,7 @@ import Inference.Monad
 import Inference.Normalise
 import MonadContext
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 import TypedFreeVar
 import Util
 import VIX
@@ -21,8 +21,8 @@ type MonadTypeOf m = (MonadIO m, MonadVIX m, MonadError Error m, MonadContext Fr
 
 typeOf
   :: MonadTypeOf m
-  => AbstractM
-  -> m AbstractM
+  => CoreM
+  -> m CoreM
 typeOf expr = case expr of
   Global v -> do
     (_, typ) <- definition v

--- a/src/Processor/File.hs
+++ b/src/Processor/File.hs
@@ -37,8 +37,8 @@ import qualified Inference.TypeCheck.Definition as TypeCheck
 import Processor.Result
 import Syntax
 import qualified Syntax.Core as Core
-import qualified Syntax.Concrete.Scoped as Concrete
-import qualified Syntax.Concrete.Unscoped as Unscoped
+import qualified Syntax.Pre.Scoped as Pre
+import qualified Syntax.Pre.Unscoped as Unscoped
 import Syntax.Sized.Anno
 import qualified Syntax.Sized.Definition as Sized
 import qualified Syntax.Sized.Extracted as Extracted
@@ -58,11 +58,11 @@ frontend
   -> VIX [k]
 frontend k
   = resolveProgramNames
-  >>=> prettyConcreteGroup "Concrete syntax" absurd
+  >>=> prettyPreGroup "Concrete syntax" absurd
 
   >=> declassifyGroup
 
-  >>=> prettyConcreteGroup "Declassified" absurd
+  >>=> prettyPreGroup "Declassified" absurd
   >=> typeCheckGroup
 
   >=> prettyTypedGroup 9 "Abstract syntax" absurd
@@ -114,13 +114,13 @@ infixr 1 >>=>
 (>>=>) :: Monad m => (a -> m [b]) -> (b -> m [c]) -> a -> m [c]
 (f >>=> g) a = concat <$> (f a >>= mapM g)
 
-prettyConcreteGroup
+prettyPreGroup
   :: (Pretty (e Doc), Monad e, Traversable e)
   => Text
   -> (v -> QName)
-  -> [(QName, SourceLoc, Concrete.TopLevelPatDefinition e v, Maybe (e v))]
-  -> VIX [(QName, SourceLoc, Concrete.TopLevelPatDefinition e v, Maybe (e v))]
-prettyConcreteGroup str f defs = do
+  -> [(QName, SourceLoc, Pre.TopLevelPatDefinition e v, Maybe (e v))]
+  -> VIX [(QName, SourceLoc, Pre.TopLevelPatDefinition e v, Maybe (e v))]
+prettyPreGroup str f defs = do
   let toDoc :: QName -> Doc
       toDoc = fromQName
   whenVerbose 10 $ do
@@ -180,7 +180,7 @@ prettyGroup str f defs = do
 
 resolveProgramNames
   :: Module (HashMap QName (SourceLoc, Unscoped.TopLevelDefinition))
-  -> VIX [[(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Type Void))]]
+  -> VIX [[(QName, SourceLoc, Pre.TopLevelPatDefinition Pre.Expr Void, Maybe (Pre.Type Void))]]
 resolveProgramNames modul = do
   res <- ResolveNames.resolveModule modul
   let defnames = HashSet.fromMap $ void $ moduleContents modul
@@ -198,8 +198,8 @@ resolveProgramNames modul = do
   return res
 
 declassifyGroup
-  :: [(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Type Void))]
-  -> VIX [[(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Type Void))]]
+  :: [(QName, SourceLoc, Pre.TopLevelPatDefinition Pre.Expr Void, Maybe (Pre.Type Void))]
+  -> VIX [[(QName, SourceLoc, Pre.TopLevelPatDefinition Pre.Expr Void, Maybe (Pre.Type Void))]]
 declassifyGroup xs = do
   results <- forM xs $
     \(name, loc, def, mtyp) -> Declassify.declassify name loc def mtyp
@@ -209,7 +209,7 @@ declassifyGroup xs = do
   return $ preResults' : [postResults' | not $ null postResults']
 
 typeCheckGroup
-  :: [(QName, SourceLoc, Concrete.TopLevelPatDefinition Concrete.Expr Void, Maybe (Concrete.Expr Void))]
+  :: [(QName, SourceLoc, Pre.TopLevelPatDefinition Pre.Expr Void, Maybe (Pre.Expr Void))]
   -> VIX [(QName, Definition (Core.Expr Void) Void, Core.Expr Void Void)]
 typeCheckGroup
   = fmap Vector.toList . TypeCheck.runInfer . TypeCheck.checkTopLevelRecursiveDefs . Vector.fromList

--- a/src/Processor/Files.hs
+++ b/src/Processor/Files.hs
@@ -18,7 +18,7 @@ import Paths_sixten(getDataFileName)
 import qualified Processor.File as File
 import Processor.Result
 import Syntax
-import qualified Syntax.Concrete.Unscoped as Unscoped
+import qualified Syntax.Pre.Unscoped as Unscoped
 import Util.TopoSort
 import VIX
 

--- a/src/Syntax/Core.hs
+++ b/src/Syntax/Core.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, FlexibleContexts, OverloadedStrings, PatternSynonyms, RankNTypes, TemplateHaskell, TypeFamilies, ViewPatterns #-}
-module Syntax.Abstract where
+module Syntax.Core where
 
 import Control.Monad
 import Data.Bifoldable

--- a/src/Syntax/Core/Pattern.hs
+++ b/src/Syntax/Core/Pattern.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, MonadComprehensions, OverloadedStrings #-}
-module Syntax.Abstract.Pattern where
+module Syntax.Core.Pattern where
 
 import Control.Applicative
 import Control.Monad

--- a/src/Syntax/Pre/Definition.hs
+++ b/src/Syntax/Pre/Definition.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, FlexibleContexts, FlexibleInstances, GADTs, OverloadedStrings, TemplateHaskell #-}
-module Syntax.Concrete.Definition where
+module Syntax.Pre.Definition where
 
 import Control.Monad
 import Data.Bifunctor
@@ -15,7 +15,7 @@ import Data.Vector(Vector)
 import Data.Void
 
 import Syntax
-import Syntax.Concrete.Pattern
+import Syntax.Pre.Pattern
 import Util
 
 data TopLevelPatDefinition expr v

--- a/src/Syntax/Pre/Literal.hs
+++ b/src/Syntax/Pre/Literal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Syntax.Concrete.Literal where
+module Syntax.Pre.Literal where
 
 import Data.ByteString as ByteString
 import Data.Text(Text)
@@ -7,8 +7,8 @@ import Data.Text.Encoding as Encoding
 import qualified Data.Vector as Vector
 
 import Syntax
-import Syntax.Concrete.Pattern
-import Syntax.Concrete.Unscoped as Unscoped
+import Syntax.Pre.Pattern
+import Syntax.Pre.Unscoped as Unscoped
 
 import qualified Builtin.Names as Builtin
 

--- a/src/Syntax/Pre/Pattern.hs
+++ b/src/Syntax/Pre/Pattern.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable, MonadComprehensions, OverloadedStrings #-}
-module Syntax.Concrete.Pattern where
+module Syntax.Pre.Pattern where
 
 import Control.Monad
 import Data.Bifoldable

--- a/src/Syntax/Pre/Scoped.hs
+++ b/src/Syntax/Pre/Scoped.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs, OverloadedStrings, PatternSynonyms, ViewPatterns #-}
-module Syntax.Concrete.Scoped
+module Syntax.Pre.Scoped
   ( module Definition
   , module Pattern
   , Expr(..), Type
@@ -20,8 +20,8 @@ import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 
 import Syntax
-import Syntax.Concrete.Definition as Definition
-import Syntax.Concrete.Pattern as Pattern
+import Syntax.Pre.Definition as Definition
+import Syntax.Pre.Pattern as Pattern
 import Util
 import Util.Tsil
 

--- a/src/Syntax/Pre/Unscoped.hs
+++ b/src/Syntax/Pre/Unscoped.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Syntax.Concrete.Unscoped where
+module Syntax.Pre.Unscoped where
 
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty(NonEmpty)
@@ -7,7 +7,7 @@ import Data.Monoid
 import Data.Vector(Vector)
 
 import Syntax hiding (Definition)
-import Syntax.Concrete.Pattern
+import Syntax.Pre.Pattern
 
 type Con = Either Constr QConstr
 
@@ -85,7 +85,7 @@ instance Pretty Expr where
     ExternCode c -> prettyM c
     Wildcard -> "_"
     SourceLoc _ e -> prettyM e
-    Syntax.Concrete.Unscoped.Error e -> prettyM e
+    Syntax.Pre.Unscoped.Error e -> prettyM e
 
 instance Pretty e => Pretty (Definition e) where
   prettyM (Definition name a cls Nothing)

--- a/src/VIX.hs
+++ b/src/VIX.hs
@@ -29,7 +29,7 @@ import Error
 import MonadFresh
 import Processor.Result
 import Syntax
-import Syntax.Abstract
+import Syntax.Core
 import qualified Syntax.Sized.Lifted as Lifted
 import TypeRep
 import Util


### PR DESCRIPTION
s/Abstract/Core
s/Concrete/Pre

I think these are better names, since concrete and abstract were perhaps not used in the standard way here.

Core is the small type theory core, and Pre is the syntax pre-typechecking.