### PR TITLE
WIP: Add file watching functionality.

### DIFF
--- a/sixten.cabal
+++ b/sixten.cabal
@@ -178,6 +178,7 @@ library
                        stm,
                        temporary,
                        text,
+                       time,
                        transformers,
                        unordered-containers,
                        vector,

--- a/sixten.cabal
+++ b/sixten.cabal
@@ -156,6 +156,7 @@ library
                        deriving-gcompare,
                        directory,
                        filepath,
+                       fsnotify,
                        hashable,
                        haskell-lsp,
                        haskell-lsp-types,

--- a/src/Command/Check/Options.hs
+++ b/src/Command/Check/Options.hs
@@ -6,4 +6,5 @@ data Options = Options
   { inputFiles :: [FilePath]
   , logPrefixes :: [Text]
   , logFile :: Maybe FilePath
+  , watch :: !Bool
   } deriving (Show)


### PR DESCRIPTION
There is some odd behavior where we perform multiple recompilations even when
just a single directory is being watched and we make a single edit. Don't know
why that is happening. Any ideas? Once that's overcome, I think this fixes #122.