### PR TITLE
Report errors through the language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2019
 
+### April
+- Added rudimentary support for reporting errors through the language server.
+
 ### March
 - Added pattern exhaustiveness and redundancy checks.
 - Added support for forced patterns (sometimes called dot patterns) (#137).

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ type Ptr a = Ref a
 
 ## Planned features
 
-* Editor integration (there's already Vim syntax highlighting though!!)
 * Records
 * Effects and IO
 * Standard library
@@ -372,6 +371,53 @@ To build Sixten programs, you'll need:
   to look for these.
 * The Boehm–Demers–Weiser garbage collector library.
 * pkg-config (used to find the Boehm–Demers–Weiser GC library).
+
+### Editor integration
+
+#### Language server
+
+The compiler has a work-in-progress language server.
+
+To install it, set up your editor's language client to use the command
+`sixten language-server`.
+
+The language server currently has the following limitations:
+
+* Only diagnostic reporting and hovering is supported.
+* Hovering only works in certain contexts.
+* Only single file projects are supported.
+* Everything is recompiled on each save.
+
+#### Vim
+
+Here's how to set up Sixten with
+[LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim/)
+using
+[vim-plug](https://github.com/junegunn/vim-plug):
+:
+
+
+```viml
+Plug 'autozimu/LanguageClient-neovim', {
+  \ 'branch': 'next',
+  \ 'do': './install.sh'
+  \ }
+
+let g:LanguageClient_serverCommands = {
+  \ 'sixten': ['~/.local/bin/sixten', 'language-server']
+  \ }
+```
+
+The above assumes that the `sixten` binary is installed locally in
+`~/.local/bin`.
+
+There are syntax highlighting definitions in the `vim` directory of the
+repository. To install it using
+[vim-plug](https://github.com/junegunn/vim-plug), use:
+
+```viml
+Plug 'ollef/sixten', { 'rtp': 'vim' }
+```
 
 ### Bash command completion
 

--- a/sixten.cabal
+++ b/sixten.cabal
@@ -70,7 +70,6 @@ library
                        Command.Compile
                        Command.Compile.Options
                        Command.LanguageServer
-                       Command.LanguageServer.Hover
                        Command.Run
                        Command.Test
                        Driver
@@ -104,6 +103,8 @@ library
                        Frontend.DupCheck
                        Frontend.Parse
                        Frontend.ResolveNames
+                       LanguageServer
+                       LanguageServer.Hover
                        Paths_sixten
                        Pretty
                        Syntax

--- a/src/Command/LanguageServer.hs
+++ b/src/Command/LanguageServer.hs
@@ -1,159 +1,13 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 module Command.LanguageServer where
 
 import Protolude hiding (handle)
 
-import Control.Concurrent.STM as STM
-import Data.Default (def)
-import qualified Data.HashMap.Lazy as HashMap
-import Data.Text(Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import qualified Language.Haskell.LSP.Control as LSP
-import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Messages as LSP
-import qualified Language.Haskell.LSP.Types as LSP
-import qualified Language.Haskell.LSP.VFS as LSP
 import Options.Applicative
-import Text.Parsix.Position
-import qualified Yi.Rope as Yi
 
-import Command.LanguageServer.Hover
-import Driver
-import Driver.Query
-import qualified Effect.Context as Context
-import Elaboration.TypeOf
-import Syntax
-import Util
-
-sendNotification :: LSP.LspFuncs () -> Text -> IO ()
-sendNotification lf s = LSP.sendFunc lf
-  $ LSP.NotLogMessage
-  $ LSP.NotificationMessage "2.0" LSP.WindowLogMessage
-  $ LSP.LogMessageParams LSP.MtInfo s
-
-sendError :: LSP.LspFuncs () -> LSP.Uri -> Error -> IO ()
-sendError lf uri e =
-  LSP.sendFunc lf
-  $ LSP.NotPublishDiagnostics
-  $ LSP.NotificationMessage "2.0" LSP.TextDocumentPublishDiagnostics
-  $ LSP.PublishDiagnosticsParams uri
-  $ LSP.List [errorToDiagnostic e]
-
-errorToDiagnostic :: Error -> LSP.Diagnostic
-errorToDiagnostic err = LSP.Diagnostic
-  { _range = maybe
-    (LSP.Range (LSP.Position 0 0) (LSP.Position 0 0))
-    (spanToRange . sourceLocSpan)
-    (errorLocation err)
-  , _severity = Just LSP.DsError
-  , _code = Nothing
-  , _source = Just "Sixten"
-  , _message = showWide $ errorSummary err <> "\n" <> errorFootnote err
-  , _relatedInformation = Nothing
-  }
-
-spanToRange :: Span -> LSP.Range
-spanToRange span = LSP.Range
-  { _start = positionToPosition $ spanStart span
-  , _end = positionToPosition $ spanEnd span
-  }
-
-positionToPosition :: Position -> LSP.Position
-positionToPosition pos = LSP.Position
-  { _line = visualRow pos
-  , _character = visualColumn pos
-  }
-
-fileContents :: LSP.LspFuncs () -> LSP.Uri -> IO Text
-fileContents lf uri = do
-  mvf <- LSP.getVirtualFileFunc lf uri
-  case mvf of
-    Just (LSP.VirtualFile _ rope) -> return $ Yi.toText rope
-    Nothing ->
-      case LSP.uriToFilePath uri of
-        Just fp -> Text.readFile fp
-        Nothing -> return "Command.LanguageServer.fileContents: file missing"
-
-hover :: LSP.LspFuncs () -> LSP.TextDocumentPositionParams -> IO (Maybe LSP.Hover)
-hover lf (LSP.TextDocumentPositionParams (LSP.TextDocumentIdentifier uri) p@(LSP.Position line char)) = do
-  sendNotification lf "Hovering!"
-  sendNotification lf (shower uri)
-  sendNotification lf (shower p)
-  contents <- fileContents lf uri
-  sendNotification lf "fileContents"
-  let
-    LSP.Uri uriText = uri
-    uriStr = Text.unpack uriText
-    onError_ = sendError lf uri
-  (types, typeOfErrs) <- Driver.executeVirtualFile uriStr contents onError_ $ do
-    defs <- fetch CheckAll
-    runHover $ do
-      (span, expr) <- hoverDefs (inside line char)
-        [ (n, loc, d, t)
-        | (n, (loc, d, t)) <- concatMap HashMap.toList defs
-        ]
-      typ <- typeOf' voidArgs expr
-      ctx <- Context.getContext
-      return (span, ctx, expr, typ)
-  sendNotification lf ("result " <> shower typeOfErrs)
-  return $ case types of
-    [] -> Nothing
-    _ -> do
-      let Just (_, (range, ctx, expr, typ)) = unsnoc types
-      Just $ LSP.Hover
-        { LSP._contents =
-          LSP.List
-            [ LSP.PlainString
-              $ showWide
-              $ pretty (traverse Context.prettyVar expr ctx)
-              <> " : "
-              <> pretty (traverse Context.prettyVar typ ctx)
-            ]
-        , LSP._range = Just
-          $ LSP.Range
-          { LSP._start = LSP.Position
-            (visualRow $ spanStart range)
-            (visualColumn $ spanStart range)
-          , LSP._end = LSP.Position
-            (visualRow $ spanEnd range)
-            (visualColumn $ spanEnd range)
-          }
-        }
-
-handle
-  :: TVar (Maybe (LSP.LspFuncs ()))
-  -> (LSP.LspFuncs () -> t -> IO resp)
-  -> (LSP.ResponseMessage resp -> LSP.FromServerMessage)
-  -> Maybe (LSP.RequestMessage m t resp -> IO ())
-handle lspFuncsRef h rspCon = Just $ \(LSP.RequestMessage jsonRpc reqId _method params) -> do
-  Just lf <- STM.readTVarIO lspFuncsRef
-  response <- h lf params
-  LSP.sendFunc lf
-    $ rspCon
-    $ LSP.ResponseMessage
-      jsonRpc
-      (LSP.responseId reqId)
-      (Just response)
-      Nothing
-
-server :: IO ()
-server = do
-  lspFuncsRef <- STM.newTVarIO (Nothing :: Maybe (LSP.LspFuncs ()))
-
-  _exitCode <- LSP.run
-    ( \_ -> Right ()
-    , \lf -> do
-      STM.atomically $ STM.writeTVar lspFuncsRef $ Just lf
-      return Nothing
-    )
-    def
-      { LSP.hoverHandler = handle lspFuncsRef hover LSP.RspHover
-      }
-    def
-    (Just "sixten-lsp.log")
-  return ()
+import qualified LanguageServer
 
 optionsParserInfo :: ParserInfo ()
 optionsParserInfo = info (pure ())
@@ -162,4 +16,4 @@ optionsParserInfo = info (pure ())
   <> header "sixten language-server"
 
 command :: ParserInfo (IO ())
-command = (\() -> server) <$> optionsParserInfo
+command = (\() -> LanguageServer.run) <$> optionsParserInfo

--- a/src/LanguageServer.hs
+++ b/src/LanguageServer.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+module LanguageServer where
+
+import Protolude hiding (handle)
+
+import Control.Concurrent.STM as STM
+import Control.Lens hiding (unsnoc)
+import Data.Default (def)
+import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.Map as Map
+import Data.Text(Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Language.Haskell.LSP.Control as LSP
+import qualified Language.Haskell.LSP.Core
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Diagnostics as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Types as LSP
+import qualified Language.Haskell.LSP.Types.Lens as LSP
+import qualified Language.Haskell.LSP.VFS as LSP
+import Text.Parsix.Position
+import qualified Yi.Rope as Yi
+
+import Driver
+import Driver.Query
+import qualified Effect.Context as Context
+import Elaboration.TypeOf
+import LanguageServer.Hover as Hover
+import Syntax
+import Util
+
+run :: IO ()
+run = do
+  messageQueue <- newTQueueIO
+  _ <- LSP.run
+    ( \_ -> Right ()
+    , \lf -> do
+      _ <- forkIO $ messagePump lf $ atomically $ readTQueue messageQueue
+      return Nothing
+    )
+    (handlers $ atomically . writeTQueue messageQueue)
+    options
+    (Just "sixten-lsp.log")
+  return ()
+
+handlers :: (LSP.FromClientMessage -> IO ()) -> LSP.Handlers
+handlers sendMessage = def
+  { LSP.hoverHandler = Just $ sendMessage . LSP.ReqHover
+  , LSP.didOpenTextDocumentNotificationHandler = Just $ sendMessage . LSP.NotDidOpenTextDocument
+  , LSP.didSaveTextDocumentNotificationHandler = Just $ sendMessage . LSP.NotDidSaveTextDocument
+  , LSP.didChangeTextDocumentNotificationHandler = Just $ sendMessage . LSP.NotDidChangeTextDocument
+  , LSP.didCloseTextDocumentNotificationHandler = Just $ sendMessage . LSP.NotDidCloseTextDocument
+  }
+
+options :: LSP.Options
+options = def
+  { Language.Haskell.LSP.Core.textDocumentSync = Just $ LSP.TextDocumentSyncOptions
+    { LSP._openClose = Just True
+    , LSP._change = Just LSP.TdSyncIncremental
+    , LSP._willSave = Just False
+    , LSP._willSaveWaitUntil = Just False
+    , LSP._save = Just $ LSP.SaveOptions $ Just False
+    }
+  }
+
+messagePump :: LSP.LspFuncs () -> IO LSP.FromClientMessage -> IO ()
+messagePump lf receiveMessage = forever $ do
+  message <- receiveMessage
+  case message of
+    LSP.NotDidOpenTextDocument notification -> do
+      sendNotification lf "messagePump: processing NotDidOpenTextDocument"
+      let
+        document = notification ^. LSP.params . LSP.textDocument . LSP.uri
+        fileName = LSP.uriToFilePath document
+      sendNotification lf $ "fileName = " <> show fileName
+      sendDiagnostics lf document
+
+    LSP.NotDidChangeTextDocument notification -> do
+      let
+        document = notification ^. LSP.params . LSP.textDocument . LSP.uri
+      (_version, _newFileContents) <- fileContents lf document
+
+      sendNotification lf $ "messagePump:processing NotDidChangeTextDocument: uri=" <> show document
+
+    LSP.NotDidSaveTextDocument notification -> do
+      sendNotification lf "messagePump: processing NotDidSaveTextDocument"
+      let
+        document = notification ^. LSP.params . LSP.textDocument . LSP.uri
+        fileName = LSP.uriToFilePath document
+      sendNotification lf $ "fileName = " <> show fileName
+      sendDiagnostics lf document
+
+    LSP.ReqHover req -> do
+      sendNotification lf $ "messagePump: HoverRequest: " <> show req
+      let
+        LSP.TextDocumentPositionParams
+          (LSP.TextDocumentIdentifier document)
+          pos@(LSP.Position line char)
+            = req ^. LSP.params
+
+      sendNotification lf $ shower document
+      sendNotification lf $ shower pos
+      (_version, contents) <- fileContents lf document
+      let
+        LSP.Uri uriText = document
+        uriStr = Text.unpack uriText
+        onError_ _ = return ()
+      (types, typeOfErrs) <- Driver.executeVirtualFile uriStr contents onError_ $ do
+        defs <- fetch CheckAll
+        runHover $ do
+          (span, expr) <- hoverDefs (Hover.inside line char)
+            [ (n, loc, d, t)
+            | (n, (loc, d, t)) <- concatMap HashMap.toList defs
+            ]
+          typ <- typeOf' voidArgs expr
+          ctx <- Context.getContext
+          return (span, ctx, expr, typ)
+      sendNotification lf $ "result " <> shower typeOfErrs
+      let
+        response = case types of
+          [] -> Nothing
+          _ -> do
+            let Just (_, (range, ctx, expr, typ)) = unsnoc types
+            Just $ LSP.Hover
+              { LSP._contents =
+                LSP.List
+                  [ LSP.PlainString
+                    $ showWide
+                    $ pretty (traverse Context.prettyVar expr ctx)
+                    <> " : "
+                    <> pretty (traverse Context.prettyVar typ ctx)
+                  ]
+              , LSP._range = Just
+                $ LSP.Range
+                { LSP._start = LSP.Position
+                  (visualRow $ spanStart range)
+                  (visualColumn $ spanStart range)
+                , LSP._end = LSP.Position
+                  (visualRow $ spanEnd range)
+                  (visualColumn $ spanEnd range)
+                }
+              }
+      LSP.sendFunc lf $ LSP.RspHover $ LSP.makeResponseMessage req response
+
+    _ ->
+      return ()
+
+-------------------------------------------------------------------------------
+sendDiagnostics :: LSP.LspFuncs () -> LSP.Uri -> IO ()
+sendDiagnostics lf document = do
+  (version, contents) <- fileContents lf document
+  LSP.flushDiagnosticsBySourceFunc lf 100 $ Just diagnosticSource
+  diagnosticsVar <- newMVar mempty
+  let
+    onError_ err = do
+      diagnostics <- modifyMVar diagnosticsVar $ \diagnostics -> do
+        let
+          newValue = errorToDiagnostic err : diagnostics
+        return (newValue, newValue)
+      LSP.publishDiagnosticsFunc lf 100 document version
+        $ LSP.partitionBySource $ reverse diagnostics
+    LSP.Uri uriText = document
+    uriStr = Text.unpack uriText
+
+  Driver.executeVirtualFile uriStr contents onError_ $ do
+    _ <- fetch CheckAll
+    return ()
+
+-------------------------------------------------------------------------------
+sendNotification :: LSP.LspFuncs () -> Text -> IO ()
+sendNotification lf s = LSP.sendFunc lf
+  $ LSP.NotLogMessage
+  $ LSP.NotificationMessage "2.0" LSP.WindowLogMessage
+  $ LSP.LogMessageParams LSP.MtInfo s
+
+diagnosticSource :: LSP.DiagnosticSource
+diagnosticSource = "sixten"
+
+sendError :: LSP.LspFuncs () -> LSP.Uri -> LSP.TextDocumentVersion -> Error -> IO ()
+sendError lf uri version e =
+  LSP.publishDiagnosticsFunc lf 10 uri version $
+    Map.singleton (Just diagnosticSource) [errorToDiagnostic e]
+
+errorToDiagnostic :: Error -> LSP.Diagnostic
+errorToDiagnostic err = LSP.Diagnostic
+  { _range = maybe
+    (LSP.Range (LSP.Position 0 0) (LSP.Position 0 0))
+    (spanToRange . sourceLocSpan)
+    (errorLocation err)
+  , _severity = Just LSP.DsError
+  , _code = Nothing
+  , _source = Just diagnosticSource
+  , _message = showWide $ errorSummary err <> "\n" <> errorFootnote err
+  , _relatedInformation = Nothing
+  }
+
+spanToRange :: Span -> LSP.Range
+spanToRange span = LSP.Range
+  { _start = positionToPosition $ spanStart span
+  , _end = positionToPosition $ spanEnd span
+  }
+
+positionToPosition :: Position -> LSP.Position
+positionToPosition pos = LSP.Position
+  { _line = visualRow pos
+  , _character = visualColumn pos
+  }
+
+fileContents :: LSP.LspFuncs () -> LSP.Uri -> IO (LSP.TextDocumentVersion, Text)
+fileContents lf uri = do
+  mvf <- LSP.getVirtualFileFunc lf uri
+  case mvf of
+    Just (LSP.VirtualFile version rope) -> return (Just version, Yi.toText rope)
+    Nothing ->
+      case LSP.uriToFilePath uri of
+        Just fp ->
+          (,) Nothing <$> Text.readFile fp
+        Nothing ->
+          return (Just 0, "")

--- a/src/LanguageServer/Hover.hs
+++ b/src/LanguageServer/Hover.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Command.LanguageServer.Hover where
+module LanguageServer.Hover where
 
 import Protolude
 
@@ -39,16 +39,16 @@ data HoverEnv = HoverEnv
 makeLenses ''HoverEnv
 
 instance HasFreshEnv HoverEnv where
-  freshEnv = Command.LanguageServer.Hover.freshEnv
+  freshEnv = LanguageServer.Hover.freshEnv
 
 instance HasContext (Expr Void Var) HoverEnv where
-  context = Command.LanguageServer.Hover.context
+  context = LanguageServer.Hover.context
 
 instance HasLogEnv HoverEnv where
-  logEnv = Command.LanguageServer.Hover.logEnv
+  logEnv = LanguageServer.Hover.logEnv
 
 instance HasReportEnv HoverEnv where
-  reportEnv = Command.LanguageServer.Hover.reportEnv
+  reportEnv = LanguageServer.Hover.reportEnv
 
 newtype Hover a = Hover { unHover :: ListT (ReaderT HoverEnv (Task Query)) a }
   deriving (Functor, Applicative, Alternative, Monad, MonadIO, Semigroup, Monoid, MonadContext (Expr Void Var), MonadFresh, MonadLog, MonadReport, MonadFetch Query)


### PR DESCRIPTION
This computes and publishes diagnostics every time a file is opened or
saved, with some limitations:

* It only works for a single file.
* It doesn't yet use the text document changed events, so you don't get
errors until you save the file.
* It recompiles everything each time you save.