### PR TITLE
Use relative source locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improved parse error recovery around top-level definitions.
 - Made the language server use incremental compilation, reusing compilation results between changes when it can.
 - Made the language server type check on every change, instead of on every save.
+- Improved caching in the incremental compiler by storing relative source locations in the syntax tree such that they don't change when they move in the file.
 
 ### March
 - Added pattern exhaustiveness and redundancy checks.

--- a/sixten.cabal
+++ b/sixten.cabal
@@ -107,6 +107,7 @@ library
                        LanguageServer.Hover
                        Paths_sixten
                        Pretty
+                       SourceLoc
                        Syntax
                        Syntax.Annotation
                        Syntax.Branches
@@ -157,6 +158,7 @@ library
                        deriving-gcompare,
                        directory,
                        filepath,
+                       fingertree,
                        fsnotify,
                        hashable,
                        haskell-lsp,

--- a/src/Analysis/Simplify.hs
+++ b/src/Analysis/Simplify.hs
@@ -17,6 +17,7 @@ import Driver.Query
 import Effect
 import qualified Effect.Context as Context
 import Elaboration.Normalise
+import SourceLoc
 import Syntax
 import Syntax.Core
 import Util

--- a/src/Builtin.hs
+++ b/src/Builtin.hs
@@ -14,6 +14,7 @@ import Backend.Target(Target)
 import Builtin.Names
 import Effect
 import qualified Effect.Context as Context
+import SourceLoc
 import Syntax
 import Syntax.Core as Core
 import Syntax.Sized.Anno

--- a/src/Effect/Report.hs
+++ b/src/Effect/Report.hs
@@ -22,6 +22,7 @@ import qualified Data.List.Class as ListT
 
 import Error
 import Pretty
+import SourceLoc
 
 class Monad m => MonadReport m where
   report :: Error -> m ()

--- a/src/Elaboration/Match.hs
+++ b/src/Elaboration/Match.hs
@@ -13,13 +13,13 @@ import Control.Monad
 import Control.Monad.Trans.Maybe
 import Data.HashMap.Lazy(HashMap)
 import qualified Data.HashMap.Lazy as HashMap
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.HashSet(HashSet)
 import qualified Data.HashSet as HashSet
+import Data.IORef
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text.Prettyprint.Doc as PP
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
-import Data.IORef
 
 import {-# SOURCE #-} Elaboration.TypeCheck.Expr
 import qualified Builtin.Names as Builtin
@@ -35,6 +35,7 @@ import Elaboration.Monad
 import Elaboration.TypeCheck.Literal
 import Elaboration.Unify
 import qualified Elaboration.Unify.Indices as Indices
+import SourceLoc
 import Syntax
 import qualified Syntax.Core as Core
 import qualified Syntax.Literal as Core

--- a/src/Elaboration/MetaVar.hs
+++ b/src/Elaboration/MetaVar.hs
@@ -16,7 +16,6 @@ import qualified Data.Vector as Vector
 
 import Effect
 import qualified Effect.Context as Context
-import Error
 import Syntax
 import Syntax.Core
 import Util
@@ -44,14 +43,13 @@ instance Hashable MetaVar where
   hashWithSalt s = hashWithSalt s . metaId
 
 instance Show MetaVar where
-  showsPrec d (MetaVar i (Closed t) a h p loc _) = showParen (d > 10) $
+  showsPrec d (MetaVar i (Closed t) a h p _ _) = showParen (d > 10) $
     showString "MetaVar" . showChar ' ' .
     showsPrec 11 i . showChar ' ' .
     showsPrec 11 (t :: Expr MetaVar Void) . showChar ' ' .
     showsPrec 11 a . showChar ' ' .
     showsPrec 11 h . showChar ' ' .
     showsPrec 11 p . showChar ' ' .
-    showsPrec 11 (pretty <$> loc) . showChar ' ' .
     showString "<Ref>"
 
 explicitExists

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -7,58 +8,8 @@ module Error where
 
 import Protolude hiding (TypeError)
 
-import Data.Text(Text)
-import Data.Text.Prettyprint.Doc(line)
-import qualified Data.Text.Prettyprint.Doc as PP
-import Data.Text.Prettyprint.Doc.Render.Terminal
-import Text.Parsix.Highlight
-import Text.Parsix.Position
-
 import Pretty
-import Util
-
-data SourceLoc = SourceLocation
-  { sourceLocFile :: FilePath
-  , sourceLocSpan :: !Span
-  , sourceLocSource :: Text
-  , sourceLocHighlights :: Highlights
-  } deriving (Eq, Ord, Show)
-
-instance Hashable SourceLoc where
-  hashWithSalt salt (SourceLocation f s _ _) = salt `hashWithSalt` f `hashWithSalt` s
-
-noSourceLoc :: FilePath -> SourceLoc
-noSourceLoc fp = SourceLocation
-  { sourceLocFile = "<no source location (" ++ fp ++ ")>"
-  , sourceLocSpan = Span (Position 0 0 0) (Position 0 0 0)
-  , sourceLocSource = mempty
-  , sourceLocHighlights = mempty
-  }
-
--- | Gives a summary (fileName:row:column) of the location
-instance Pretty SourceLoc where
-  pretty src
-    = pretty (sourceLocFile src)
-    <> ":" <>
-    if spanStart span == spanEnd span then
-      shower startRow <> ":" <> shower startCol
-    else if startRow == endRow then
-      shower startRow <> ":" <> shower startCol <> "-" <> shower endCol
-    else
-      shower startRow <> ":" <> shower startCol <> "-" <> shower endRow <> ":" <> shower endCol
-    where
-      span = sourceLocSpan src
-      startRow = visualRow (spanStart span) + 1
-      endRow = visualRow (spanEnd span) + 1
-      startCol = visualColumn (spanStart span) + 1
-      endCol = visualColumn (spanEnd span) + 1
-
-locationRendering :: SourceLoc -> Doc
-locationRendering src = prettySpan
-  defaultStyle
-  (sourceLocSpan src)
-  (sourceLocSource src)
-  (sourceLocHighlights src)
+import SourceLoc
 
 data ErrorKind
   = SyntaxErrorKind
@@ -99,17 +50,3 @@ pattern CommandLineError s l f = Error CommandLineErrorKind s l f
 
 pattern InternalError :: Doc -> Maybe SourceLoc -> Doc -> Error
 pattern InternalError s l f = Error InternalErrorKind s l f
-
-instance Pretty Error where
-  pretty (Error kind summary (Just loc) footnote)
-    = pretty loc <> ":" PP.<+> red (pretty kind) <> ":" PP.<+> summary
-    <> line <> locationRendering loc
-    <> line <> footnote
-    <> line
-  pretty (Error kind summary Nothing footnote)
-    = red (pretty kind) <> ":" <> summary
-    <> line <> footnote
-    <> line
-
-printError :: Error -> IO ()
-printError = putDoc . pretty

--- a/src/Frontend/DupCheck.hs
+++ b/src/Frontend/DupCheck.hs
@@ -5,15 +5,14 @@ module Frontend.DupCheck where
 import Protolude hiding (TypeError)
 
 import Control.Monad.State
-import Data.Char
 import Data.HashMap.Lazy(HashMap)
 import qualified Data.HashMap.Lazy as HashMap
-import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as PP
+import Text.Parsix.Position
 
+import Driver.Query
 import Syntax
 import qualified Syntax.Pre.Unscoped as Pre
-import Util
 
 data DupState = DupState
   { instanceNumber :: !Int
@@ -21,37 +20,33 @@ data DupState = DupState
   }
 
 dupCheck
-  :: ModuleName
-  -> [(SourceLoc, Pre.Definition)]
-  -> (HashMap QName (SourceLoc, Pre.Definition), [Error])
-dupCheck mname = second errors . flip runState (DupState 0 []) . foldM go mempty
+  :: [(QName, AbsoluteSourceLoc, Pre.Definition)]
+  -> Task Query (HashMap QName (SourceLoc, Pre.Definition), [Error])
+dupCheck
+  = fmap (second errors)
+  . flip runStateT (DupState 0 [])
+  . foldM go mempty
   where
-    go defs (loc, def) = do
-      name <- case def of
-        Pre.ConstantDefinition d -> return $ Pre.definitionName d
-        Pre.DataDefinition _ n _ _ -> return n
-        Pre.ClassDefinition n _ _ -> return n
-        Pre.InstanceDefinition typ _ -> do
-          i <- gets instanceNumber
-          modify' $ \s -> s { instanceNumber = instanceNumber s + 1 }
-          return $ "instance-" <> shower i <> instanceNameEnding (shower $ pretty typ)
-      let qname = QName mname name
-      if HashMap.member qname defs then do
+    go defs (name, loc@(Syntax.AbsoluteSourceLoc _ span _), def)
+      | name `HashMap.member` defs = do
         let
-          (prevLoc, _) = defs HashMap.! qname
+          (prevLoc, _) = defs HashMap.! name
+        aprevLoc <- fetchAbsoluteSourceLoc prevLoc
+        renderedPrevLoc <- fetchLocationRendering prevLoc
+        let
           err = TypeError
             "Duplicate definition"
-            (Just loc)
+            (Just $ Absolute loc)
             $ PP.vcat
-              [ "Previous definition at " <> pretty prevLoc
-              , pretty prevLoc
+              [ "Previous definition at " <> pretty aprevLoc
+              , renderedPrevLoc
               ]
         modify' $ \s -> s { errors = err : errors s }
         return defs
-      else return $ HashMap.insert qname (loc, def) defs
-      where
-        instanceNameEnding n
-          | Text.all (\b -> isAlphaNum b || isSpace b) n = fromText $ "-" <> Text.map replaceSpace n
-          | otherwise = ""
-        replaceSpace ' ' = '-'
-        replaceSpace c = c
+      | otherwise = do
+        let
+          loc'
+            = Relative
+            $ RelativeSourceLoc name
+            $ spanRelativeTo (spanStart span) span
+        return $ HashMap.insert name (loc', def) defs

--- a/src/SourceLoc.hs
+++ b/src/SourceLoc.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+module SourceLoc where
+
+import Protolude hiding (TypeError)
+
+import Text.Parsix.Highlight
+import Text.Parsix.Position
+
+import Pretty
+import Syntax.QName
+import Util
+
+data SourceLoc
+  = Absolute !AbsoluteSourceLoc
+  | Relative !RelativeSourceLoc
+  deriving (Eq, Ord, Show, Generic, Hashable)
+
+noSourceLoc :: FilePath -> SourceLoc
+noSourceLoc fp = Absolute $ AbsoluteSourceLoc
+  { absoluteFile = fp
+  , absoluteSpan = Span mempty mempty
+  , absoluteHighlights = Nothing
+  }
+
+data AbsoluteSourceLoc = AbsoluteSourceLoc
+  { absoluteFile :: FilePath
+  , absoluteSpan :: !Span
+  , absoluteHighlights :: !(Maybe Highlights)
+  } deriving (Eq, Ord, Show, Generic, Hashable)
+
+data RelativeSourceLoc = RelativeSourceLoc
+  { relativeTo :: !QName
+  , relativeSpan :: !Span
+  } deriving (Eq, Ord, Show, Generic, Hashable)
+
+spanRelativeTo :: Position -> Span -> Span
+spanRelativeTo p (Span start end) = Span
+  { spanStart = positionRelativeTo p start
+  , spanEnd = positionRelativeTo p end
+  }
+
+positionRelativeTo :: Position -> Position -> Position
+positionRelativeTo p1 p2 = Position
+  { codeUnits = codeUnits p2 - codeUnits p1
+  , visualRow = visualRow p2 - visualRow p1
+  , visualColumn =
+    if visualRow p1 == visualRow p2 then
+      visualColumn p2 - visualColumn p1
+    else
+      visualColumn p2
+  }
+
+-- | Gives a summary (fileName:row:column) of the location
+instance Pretty AbsoluteSourceLoc where
+  pretty src
+    = pretty (absoluteFile src)
+    <> ":" <>
+    if spanStart span == spanEnd span then
+      shower startRow <> ":" <> shower startCol
+    else if startRow == endRow then
+      shower startRow <> ":" <> shower startCol <> "-" <> shower endCol
+    else
+      shower startRow <> ":" <> shower startCol <> "-" <> shower endRow <> ":" <> shower endCol
+    where
+      span = absoluteSpan src
+      startRow = visualRow (spanStart span) + 1
+      endRow = visualRow (spanEnd span) + 1
+      startCol = visualColumn (spanStart span) + 1
+      endCol = visualColumn (spanEnd span) + 1

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -7,6 +7,7 @@ import Control.Monad.Morph as X
 import qualified Util
 
 import Error as X
+import SourceLoc as X
 import Pretty as X
 import Syntax.Annotation as X
 import Syntax.Branches as X

--- a/src/Syntax/Class.hs
+++ b/src/Syntax/Class.hs
@@ -18,8 +18,8 @@ import Data.Functor.Classes
 import Data.Vector(Vector)
 
 import Effect.Context as Context
-import Error
 import Pretty
+import SourceLoc
 import Syntax.GlobalBind
 import Syntax.Name
 import Syntax.Telescope

--- a/src/Syntax/Let.hs
+++ b/src/Syntax/Let.hs
@@ -24,8 +24,8 @@ import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 
 import Effect
+import SourceLoc
 import qualified Effect.Context as Context
-import Error
 import Pretty
 import Syntax.Annotation
 import Syntax.GlobalBind

--- a/src/Syntax/Pattern.hs
+++ b/src/Syntax/Pattern.hs
@@ -21,8 +21,8 @@ import Data.Hashable.Lifted
 import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 
-import Error
 import Pretty
+import SourceLoc
 import Syntax.Annotation
 import Syntax.Name
 import Util

--- a/src/Syntax/PreName.hs
+++ b/src/Syntax/PreName.hs
@@ -5,8 +5,8 @@ import Protolude
 import Data.String
 import Data.Text(Text)
 
-import Error
 import Pretty
+import SourceLoc
 import Util
 
 -- | An unresolved name

--- a/src/Syntax/Sized/SLambda.hs
+++ b/src/Syntax/Sized/SLambda.hs
@@ -18,6 +18,7 @@ import Data.Deriving
 import Data.Vector(Vector)
 import qualified Data.Vector as Vector
 
+import SourceLoc
 import Effect
 import qualified Effect.Context as Context
 import Syntax

--- a/src/Util/Orphans.hs
+++ b/src/Util/Orphans.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Util.Orphans where
 
@@ -7,6 +9,9 @@ import Protolude
 
 import Data.Bifunctor.Flip
 import Data.Hashable.Lifted
+import Data.IntervalMap.FingerTree(IntervalMap)
+import Text.Parser.Token.Highlight
+import Data.IntervalMap.FingerTree as IntervalMap
 import Data.Vector(Vector)
 import Data.Vector.Instances()
 import qualified LLVM.AST as LLVM
@@ -35,9 +40,16 @@ instance Hashable Position where
 
 instance Hashable Span where
 
+deriving instance Generic Highlight
+instance Hashable Highlight
+
 instance Hashable1 NonEmpty where
 
 instance Hashable (g b a) => Hashable (Flip g a b) where
+
+instance Hashable a => Hashable (IntervalMap.Interval a) where
+instance (Ord v, Hashable v, Hashable a) => Hashable (IntervalMap v a) where
+  hashWithSalt s i = hashWithSalt s $ (`IntervalMap.intersections` i) <$> IntervalMap.bounds i
 
 instance Hashable LLVM.AddrSpace where
 instance Hashable LLVM.BasicBlock where

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,8 @@ packages:
 - '.'
 extra-deps:
 - llvm-hs-pretty-0.6.1.0
-- parsix-0.2.0.0
+- parsix-0.2.1.0
 - git: https://github.com/ollef/deriving-gcompare.git
   commit: 6d26b859fce3fcae181bde4c8d1b3a6d98e26068
 - git: https://github.com/ollef/rock.git
-  commit: f6c02b1e638f40586a5d61db0b25147db53fbd9f
+  commit: 5915da824ae7e61cda15af346ad3f9731667b9bb


### PR DESCRIPTION
This makes the language server able to cache elaboration results even
if definitions have been moved around in the source file.

This required moving the naming of instances from the dup checker to the
parser such that the parser can produce relative source locations for
those as well.

Fixes #141.